### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/douglasrlee/paychecq/security/code-scanning/8](https://github.com/douglasrlee/paychecq/security/code-scanning/8)

In general, the fix is to define a `permissions:` block to restrict the `GITHUB_TOKEN` to the minimum necessary scopes. This can be done once at the top level of the workflow (applies to all jobs without their own `permissions:`) or per job. Since all jobs here only need to read repository contents (for `actions/checkout`, running tests, and using `actions/upload-artifact`), we can safely set `contents: read`.

The best minimally invasive fix is to add a single root-level `permissions:` block just below the `name: CI` line. This will cover `scan_ruby`, `lint`, `test`, and `system-test` without altering their behavior, and directly addresses the CodeQL complaint about the `system-test` job. No other code changes or imports are needed, and no job-specific overrides are required because none of the jobs write to the repo or PRs.

Concretely: edit `.github/workflows/ci.yml` and insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: CI`) and before the `on:` block at line 3. Indentation should match YAML root-level keys.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
