### PR TITLE
Add transaction name overrides

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -2,6 +2,7 @@ class SettingsController < ApplicationController
   def show
     @bank = Current.user.banks.includes(:bank_accounts).first
     @push_notifications_enabled = Current.user.push_subscriptions.exists?
+    @transaction_name_overrides = Current.user.transaction_name_overrides.order(:match_type, :match_text).to_a
 
     if @bank
       if @bank.needs_attention? && !@bank.disconnected?

--- a/app/controllers/transaction_name_overrides_controller.rb
+++ b/app/controllers/transaction_name_overrides_controller.rb
@@ -1,0 +1,71 @@
+class TransactionNameOverridesController < ApplicationController
+  before_action :set_override, only: [ :destroy ]
+
+  rescue_from ActiveRecord::RecordNotFound do
+    respond_to do |format|
+      format.turbo_stream { head :no_content }
+      format.html { redirect_to settings_path }
+    end
+  end
+
+  def create
+    @override = Current.user.transaction_name_overrides.new(override_params)
+
+    if @override.save
+      @transaction_name_overrides = Current.user.transaction_name_overrides.to_a
+      @matching_transactions = matching_transactions(@override)
+      load_transaction_for_drawer
+
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_to transactions_path, status: :see_other }
+      end
+    else
+      redirect_to safe_return_path, status: :see_other, alert: @override.errors.full_messages.to_sentence
+    end
+  end
+
+  def destroy
+    @matching_transactions = matching_transactions(@override)
+    @override.destroy
+    @transaction_name_overrides = Current.user.transaction_name_overrides.to_a
+    load_transaction_for_drawer
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to safe_return_path, status: :see_other }
+    end
+  end
+
+  private
+
+  def set_override
+    @override = Current.user.transaction_name_overrides.find(params[:id])
+  end
+
+  def override_params
+    params.expect(transaction_name_override: [ :match_type, :match_text, :replacement_name ])
+  end
+
+  def load_transaction_for_drawer
+    return if params[:transaction_id].blank?
+
+    @transaction = Current.user.transactions.includes(:bank_account).find(params[:transaction_id])
+    @transaction_name_override = @transaction.applied_override(@transaction_name_overrides)
+  end
+
+  def matching_transactions(override)
+    transactions = Current.user.transactions
+    case override.match_type
+    when 'exact'
+      transactions.where('LOWER(transactions.name) = LOWER(?)', override.match_text)
+    when 'contains'
+      transactions.where('LOWER(transactions.name) LIKE ?', "%#{ActiveRecord::Base.sanitize_sql_like(override.match_text.downcase)}%")
+    end
+  end
+
+  def safe_return_path
+    return_to = params[:return_to]
+    return_to&.start_with?('/') ? return_to : settings_path
+  end
+end

--- a/app/controllers/transaction_name_overrides_controller.rb
+++ b/app/controllers/transaction_name_overrides_controller.rb
@@ -65,7 +65,7 @@ class TransactionNameOverridesController < ApplicationController
   end
 
   def safe_return_path
-    return_to = params[:return_to]
-    return_to&.start_with?('/') ? return_to : settings_path
+    return_to = params[:return_to].to_s
+    return_to.start_with?('/') && !return_to.start_with?('//') ? return_to : settings_path
   end
 end

--- a/app/controllers/transaction_name_overrides_controller.rb
+++ b/app/controllers/transaction_name_overrides_controller.rb
@@ -26,7 +26,7 @@ class TransactionNameOverridesController < ApplicationController
   end
 
   def destroy
-    @matching_transactions = matching_transactions(@override)
+    @matching_transactions = matching_transactions(@override) if params[:transaction_id].present?
     @override.destroy
     @transaction_name_overrides = Current.user.transaction_name_overrides.to_a
     load_transaction_for_drawer

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -1,6 +1,20 @@
 class TransactionsController < ApplicationController
   def index
+    @transaction_name_overrides = Current.user.transaction_name_overrides.to_a
     @transactions = Current.user.transactions.order(Arel.sql('date DESC NULLS LAST, created_at DESC')).load
     @has_bank = Current.user.banks.exists? if @transactions.empty?
+  end
+
+  def show
+    @transaction = Current.user.transactions.includes(:bank_account).find(params[:id])
+    @transaction_name_overrides = Current.user.transaction_name_overrides.to_a
+    @transaction_name_override = find_transaction_name_override(@transaction, @transaction_name_overrides)
+  end
+
+  private
+
+  def find_transaction_name_override(transaction, transaction_name_overrides)
+    transaction_name_overrides.find { |o| o.match_type == 'exact' && transaction.name.casecmp?(o.match_text) } ||
+      transaction_name_overrides.find { |o| o.match_type == 'contains' && transaction.name.downcase.include?(o.match_text.downcase) }
   end
 end

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -8,13 +8,6 @@ class TransactionsController < ApplicationController
   def show
     @transaction = Current.user.transactions.includes(:bank_account).find(params[:id])
     @transaction_name_overrides = Current.user.transaction_name_overrides.to_a
-    @transaction_name_override = find_transaction_name_override(@transaction, @transaction_name_overrides)
-  end
-
-  private
-
-  def find_transaction_name_override(transaction, transaction_name_overrides)
-    transaction_name_overrides.find { |o| o.match_type == 'exact' && transaction.name.casecmp?(o.match_text) } ||
-      transaction_name_overrides.find { |o| o.match_type == 'contains' && transaction.name.downcase.include?(o.match_text.downcase) }
+    @transaction_name_override = @transaction.applied_override(@transaction_name_overrides)
   end
 end

--- a/app/javascript/controllers/dismissible_controller.js
+++ b/app/javascript/controllers/dismissible_controller.js
@@ -1,0 +1,56 @@
+import { Controller } from "@hotwired/stimulus"
+
+const ANIMATION_DURATION = 200
+
+export default class extends Controller {
+  connect() {
+    this.handleStreamRender = this.handleStreamRender.bind(this)
+    document.addEventListener("turbo:before-stream-render", this.handleStreamRender)
+  }
+
+  disconnect() {
+    document.removeEventListener("turbo:before-stream-render", this.handleStreamRender)
+  }
+
+  handleStreamRender(event) {
+    const stream = event.detail.newStream
+    if (stream.getAttribute("action") !== "remove") return
+    if (stream.getAttribute("target") !== this.element.id) return
+
+    this.startDismissAnimation()
+
+    const originalRender = event.detail.render
+    event.detail.render = async (streamElement) => {
+      await new Promise(resolve => setTimeout(resolve, ANIMATION_DURATION + 20))
+      this.maybeShowSiblingEmptyState()
+      await originalRender(streamElement)
+    }
+  }
+
+  maybeShowSiblingEmptyState() {
+    const parent = this.element.parentElement
+    if (!parent) return
+    const remaining = Array.from(parent.querySelectorAll('[data-controller~="dismissible"]'))
+      .filter(el => el !== this.element)
+    if (remaining.length === 0) {
+      const empty = parent.querySelector("[data-empty-state]")
+      if (empty) empty.classList.remove("hidden")
+    }
+  }
+
+  startDismissAnimation() {
+    const el = this.element
+    const height = el.offsetHeight
+    el.style.overflow = "hidden"
+    el.style.maxHeight = `${height}px`
+    el.style.transition = `max-height ${ANIMATION_DURATION}ms ease-out, opacity ${ANIMATION_DURATION}ms ease-out, margin ${ANIMATION_DURATION}ms ease-out, padding ${ANIMATION_DURATION}ms ease-out`
+    requestAnimationFrame(() => {
+      el.style.maxHeight = "0"
+      el.style.opacity = "0"
+      el.style.marginTop = "0"
+      el.style.marginBottom = "0"
+      el.style.paddingTop = "0"
+      el.style.paddingBottom = "0"
+    })
+  }
+}

--- a/app/javascript/controllers/drawer_controller.js
+++ b/app/javascript/controllers/drawer_controller.js
@@ -1,0 +1,29 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["panel", "overlay"]
+
+  connect() {
+    this.handleEscape = this.handleEscape.bind(this)
+  }
+
+  open() {
+    this.overlayTarget.classList.remove("opacity-0", "pointer-events-none")
+    this.panelTarget.classList.remove("translate-x-full")
+    document.addEventListener("keydown", this.handleEscape)
+  }
+
+  close() {
+    this.overlayTarget.classList.add("opacity-0", "pointer-events-none")
+    this.panelTarget.classList.add("translate-x-full")
+    document.removeEventListener("keydown", this.handleEscape)
+  }
+
+  handleEscape(event) {
+    if (event.key === "Escape") this.close()
+  }
+
+  disconnect() {
+    document.removeEventListener("keydown", this.handleEscape)
+  }
+}

--- a/app/javascript/controllers/drawer_controller.js
+++ b/app/javascript/controllers/drawer_controller.js
@@ -13,7 +13,8 @@ export default class extends Controller {
     document.addEventListener("keydown", this.handleEscape)
   }
 
-  close() {
+  close(event) {
+    if (event) event.preventDefault()
     this.overlayTarget.classList.add("opacity-0", "pointer-events-none")
     this.panelTarget.classList.add("translate-x-full")
     document.removeEventListener("keydown", this.handleEscape)

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -5,17 +5,23 @@
 import { application } from "./application";
 
 import AutoDismissController from "./auto_dismiss_controller";
+import DismissibleController from "./dismissible_controller";
+import DrawerController from "./drawer_controller";
 import LoadingButtonController from "./loading_button_controller";
 import PlaidLinkController from "./plaid_link_controller";
 import PullToRefreshController from "./pull_to_refresh_controller";
 import PushNotificationController from "./push_notification_controller";
 import ScrollToTopController from "./scroll_to_top_controller";
 import SwipeNavController from "./swipe_nav_controller";
+import ToggleController from "./toggle_controller";
 
 application.register("auto-dismiss", AutoDismissController);
+application.register("dismissible", DismissibleController);
+application.register("drawer", DrawerController);
 application.register("loading-button", LoadingButtonController);
 application.register("plaid-link", PlaidLinkController);
 application.register("pull-to-refresh", PullToRefreshController);
 application.register("push-notification", PushNotificationController);
 application.register("scroll-to-top", ScrollToTopController);
 application.register("swipe-nav", SwipeNavController);
+application.register("toggle", ToggleController);

--- a/app/javascript/controllers/loading_button_controller.js
+++ b/app/javascript/controllers/loading_button_controller.js
@@ -14,12 +14,14 @@ export default class extends Controller {
   }
 
   showLoading = () => {
-    this.originalContent = this.element.innerHTML;
-    this.element.innerHTML = `<span class="loading loading-spinner loading-sm"></span> ${this.textValue}`;
     this.element.classList.add("pointer-events-none", "opacity-70");
 
-    if (this.element.tagName === "BUTTON") {
-      this.element.disabled = true;
-    }
+    setTimeout(() => {
+      this.originalContent = this.element.innerHTML;
+      this.element.innerHTML = `<span class="loading loading-spinner loading-sm"></span> ${this.textValue}`;
+      if (this.element.tagName === "BUTTON") {
+        this.element.disabled = true;
+      }
+    }, 0);
   };
 }

--- a/app/javascript/controllers/toggle_controller.js
+++ b/app/javascript/controllers/toggle_controller.js
@@ -1,0 +1,79 @@
+import { Controller } from "@hotwired/stimulus"
+
+const ANIMATION_DURATION = 200
+
+export default class extends Controller {
+  static targets = ["content"]
+  static values = { delayFrame: String }
+
+  connect() {
+    this.handleStreamRender = this.handleStreamRender.bind(this)
+    document.addEventListener("turbo:before-stream-render", this.handleStreamRender)
+  }
+
+  disconnect() {
+    document.removeEventListener("turbo:before-stream-render", this.handleStreamRender)
+  }
+
+  close() {
+    const content = this.contentTarget
+    if (!content.classList.contains("hidden")) this.slideClose(content)
+  }
+
+  toggle() {
+    const content = this.contentTarget
+    if (content.classList.contains("hidden")) {
+      this.slideOpen(content)
+    } else {
+      this.slideClose(content)
+    }
+  }
+
+  // Delay stream renders targeting our frame so the close animation finishes first
+  handleStreamRender(event) {
+    if (!this.delayFrameValue) return
+
+    const stream = event.detail.newStream
+    const action = stream.getAttribute("action")
+    const target = stream.getAttribute("target")
+    const isFrameUpdate = [ "update", "replace" ].includes(action) && target === this.delayFrameValue
+
+    if (isFrameUpdate) {
+      const originalRender = event.detail.render
+      event.detail.render = async (streamElement) => {
+        await new Promise(resolve => setTimeout(resolve, ANIMATION_DURATION + 20))
+        await originalRender(streamElement)
+      }
+    }
+  }
+
+  slideOpen(content) {
+    content.classList.remove("hidden")
+    content.style.overflow = "hidden"
+    content.style.maxHeight = "0"
+    content.style.transition = `max-height ${ANIMATION_DURATION}ms ease-out`
+    requestAnimationFrame(() => {
+      content.style.maxHeight = content.scrollHeight + "px"
+    })
+    content.addEventListener("transitionend", () => {
+      content.style.maxHeight = ""
+      content.style.overflow = ""
+      content.style.transition = ""
+    }, { once: true })
+  }
+
+  slideClose(content) {
+    content.style.maxHeight = content.scrollHeight + "px"
+    content.style.overflow = "hidden"
+    content.style.transition = `max-height ${ANIMATION_DURATION}ms ease-out`
+    requestAnimationFrame(() => {
+      content.style.maxHeight = "0"
+    })
+    content.addEventListener("transitionend", () => {
+      content.classList.add("hidden")
+      content.style.maxHeight = ""
+      content.style.overflow = ""
+      content.style.transition = ""
+    }, { once: true })
+  }
+}

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -16,8 +16,11 @@ class Transaction < ApplicationRecord
   end
 
   def applied_override(transaction_name_overrides)
-    transaction_name_overrides.find { |o| o.match_type == 'exact' && name.casecmp?(o.match_text) } ||
-      transaction_name_overrides.find { |o| o.match_type == 'contains' && name.downcase.include?(o.match_text.downcase) }
+    exact = transaction_name_overrides.find { |o| o.match_type == 'exact' && name.casecmp?(o.match_text) }
+    return exact if exact
+
+    downcased_name = name.downcase
+    transaction_name_overrides.find { |o| o.match_type == 'contains' && downcased_name.include?(o.match_text.downcase) }
   end
 
   def safe_logo_url

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -7,6 +7,19 @@ class Transaction < ApplicationRecord
   validates :amount, numericality: true
   validates :plaid_transaction_id, uniqueness: true, allow_nil: true
 
+  def display_name(transaction_name_overrides = [])
+    applied_override(transaction_name_overrides)&.replacement_name || name
+  end
+
+  def display_label(transaction_name_overrides = [])
+    applied_override(transaction_name_overrides)&.replacement_name || merchant_name.presence || name
+  end
+
+  def applied_override(transaction_name_overrides)
+    transaction_name_overrides.find { |o| o.match_type == 'exact' && name.casecmp?(o.match_text) } ||
+      transaction_name_overrides.find { |o| o.match_type == 'contains' && name.downcase.include?(o.match_text.downcase) }
+  end
+
   def safe_logo_url
     return nil if logo_url.blank?
 

--- a/app/models/transaction_name_override.rb
+++ b/app/models/transaction_name_override.rb
@@ -1,0 +1,13 @@
+class TransactionNameOverride < ApplicationRecord
+  belongs_to :user
+
+  MATCH_TYPES = %w[exact contains].freeze
+
+  validates :match_type, inclusion: { in: MATCH_TYPES, message: 'must be exact or contains' }
+  validates :match_text, :replacement_name, presence: true
+  validates :match_text, uniqueness: {
+    scope: [ :user_id, :match_type ],
+    case_sensitive: false,
+    message: 'already has an override for this match type'
+  }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
   has_many :bank_accounts, through: :banks
   has_many :transactions, through: :bank_accounts
   has_many :push_subscriptions, dependent: :destroy
+  has_many :transaction_name_overrides, dependent: :destroy
 
   validates :first_name, :last_name, :email_address, presence: true
   validates :email_address, uniqueness: { case_sensitive: false }

--- a/app/services/push_notification_service.rb
+++ b/app/services/push_notification_service.rb
@@ -10,17 +10,18 @@ class PushNotificationService
     return if subscriptions.empty?
 
     if transactions.size <= MAX_INDIVIDUAL_NOTIFICATIONS
-      send_individual_notifications(subscriptions, transactions)
+      transaction_name_overrides = user.transaction_name_overrides.to_a
+      send_individual_notifications(subscriptions, transactions, transaction_name_overrides)
     else
       send_summary_notification(subscriptions, transactions.size)
     end
   end
 
-  def self.send_individual_notifications(subscriptions, transactions)
+  def self.send_individual_notifications(subscriptions, transactions, transaction_name_overrides)
     transactions.each do |transaction|
       payload = {
         title: 'New Transaction',
-        body: "#{transaction.name} — #{ActiveSupport::NumberHelper.number_to_currency(transaction.amount)}",
+        body: "#{transaction.display_label(transaction_name_overrides)} — #{ActiveSupport::NumberHelper.number_to_currency(transaction.amount)}",
         path: '/',
         tag: "transaction-#{transaction.id}"
       }.to_json

--- a/app/views/components/_radio_button.html.erb
+++ b/app/views/components/_radio_button.html.erb
@@ -1,0 +1,6 @@
+<%# locals: (form:, field:, value:, label:, checked: false) %>
+
+<label class="flex items-center gap-2 cursor-pointer">
+  <%= form.radio_button field, value, checked: checked, class: "radio radio-sm radio-primary" %>
+  <span class="text-sm"><%= label %></span>
+</label>

--- a/app/views/settings/_transaction_name_overrides.html.erb
+++ b/app/views/settings/_transaction_name_overrides.html.erb
@@ -1,0 +1,15 @@
+<div class="card card-lg bg-base-100 mt-6 w-full max-w-240 shadow-glow">
+  <div class="card-body">
+    <h2 class="card-title">Transaction Name Overrides</h2>
+    <p class="text-sm text-base-content/60 mt-1">Automatically rename transactions based on matching rules. Exact match takes priority over contains.</p>
+
+    <div class="space-y-2 mt-2">
+      <% @transaction_name_overrides.each do |override| %>
+        <%= render override %>
+      <% end %>
+      <p data-empty-state class="text-sm text-base-content/40 text-center py-6 <%= 'hidden' if @transaction_name_overrides.any? %>">
+        No overrides yet. Edit a transaction name to add one.
+      </p>
+    </div>
+  </div>
+</div>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -1,4 +1,5 @@
-<div class="flex flex-col items-center">
+<div class="flex flex-col items-center pb-10">
   <%= render "settings/notifications" %>
   <%= render "settings/linked_account" %>
+  <%= render "settings/transaction_name_overrides" %>
 </div>

--- a/app/views/transaction_name_overrides/_transaction_name_override.html.erb
+++ b/app/views/transaction_name_overrides/_transaction_name_override.html.erb
@@ -1,0 +1,19 @@
+<div id="<%= dom_id(transaction_name_override) %>" data-controller="dismissible" class="flex items-center justify-between px-4 py-3 gap-3 bg-base-200 rounded-xl">
+  <div class="flex items-center gap-2 min-w-0 flex-1 text-sm">
+    <span class="badge badge-sm <%= transaction_name_override.match_type == "exact" ? "badge-primary" : "badge-secondary" %> shrink-0">
+      <%= transaction_name_override.match_type == "exact" ? "Exact" : "Contains" %>
+    </span>
+    <span class="truncate text-base-content/70">"<%= transaction_name_override.match_text %>"</span>
+    <span class="text-base-content/40 shrink-0">→</span>
+    <span class="font-medium truncate">"<%= transaction_name_override.replacement_name %>"</span>
+  </div>
+
+  <%= button_to transaction_name_override_path(transaction_name_override),
+      method: :delete,
+      class: "btn btn-ghost btn-sm text-error shrink-0",
+      data: { controller: "loading-button", loading_button_text_value: "" } do %>
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+    </svg>
+  <% end %>
+</div>

--- a/app/views/transaction_name_overrides/create.turbo_stream.erb
+++ b/app/views/transaction_name_overrides/create.turbo_stream.erb
@@ -1,0 +1,15 @@
+<% @matching_transactions.each do |transaction| %>
+  <%= turbo_stream.replace transaction do %>
+    <%= render transaction, transaction_name_overrides: @transaction_name_overrides %>
+  <% end %>
+<% end %>
+
+<% if @transaction %>
+  <%= turbo_stream.replace "transaction_detail" do %>
+    <%= turbo_frame_tag "transaction_detail" do %>
+      <%= render "transactions/transaction_detail",
+          transaction: @transaction,
+          transaction_name_override: @transaction_name_override %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/transaction_name_overrides/create.turbo_stream.erb
+++ b/app/views/transaction_name_overrides/create.turbo_stream.erb
@@ -1,10 +1,10 @@
-<% @matching_transactions.each do |transaction| %>
-  <%= turbo_stream.replace transaction do %>
-    <%= render transaction, transaction_name_overrides: @transaction_name_overrides %>
-  <% end %>
-<% end %>
-
 <% if @transaction %>
+  <% @matching_transactions.each do |transaction| %>
+    <%= turbo_stream.replace transaction do %>
+      <%= render transaction, transaction_name_overrides: @transaction_name_overrides %>
+    <% end %>
+  <% end %>
+
   <%= turbo_stream.replace "transaction_detail" do %>
     <%= turbo_frame_tag "transaction_detail" do %>
       <%= render "transactions/transaction_detail",

--- a/app/views/transaction_name_overrides/destroy.turbo_stream.erb
+++ b/app/views/transaction_name_overrides/destroy.turbo_stream.erb
@@ -1,0 +1,17 @@
+<% @matching_transactions.each do |transaction| %>
+  <%= turbo_stream.replace transaction do %>
+    <%= render transaction, transaction_name_overrides: @transaction_name_overrides %>
+  <% end %>
+<% end %>
+
+<% if @transaction %>
+  <%= turbo_stream.replace "transaction_detail" do %>
+    <%= turbo_frame_tag "transaction_detail" do %>
+      <%= render "transactions/transaction_detail",
+          transaction: @transaction,
+          transaction_name_override: @transaction_name_override %>
+    <% end %>
+  <% end %>
+<% else %>
+  <%= turbo_stream.remove @override %>
+<% end %>

--- a/app/views/transaction_name_overrides/destroy.turbo_stream.erb
+++ b/app/views/transaction_name_overrides/destroy.turbo_stream.erb
@@ -1,10 +1,10 @@
-<% @matching_transactions.each do |transaction| %>
-  <%= turbo_stream.replace transaction do %>
-    <%= render transaction, transaction_name_overrides: @transaction_name_overrides %>
-  <% end %>
-<% end %>
-
 <% if @transaction %>
+  <% @matching_transactions.each do |transaction| %>
+    <%= turbo_stream.replace transaction do %>
+      <%= render transaction, transaction_name_overrides: @transaction_name_overrides %>
+    <% end %>
+  <% end %>
+
   <%= turbo_stream.replace "transaction_detail" do %>
     <%= turbo_frame_tag "transaction_detail" do %>
       <%= render "transactions/transaction_detail",

--- a/app/views/transactions/_transaction.html.erb
+++ b/app/views/transactions/_transaction.html.erb
@@ -1,8 +1,12 @@
-<div id="<%= dom_id transaction %>" class="flex items-center justify-between gap-4 px-5 py-4 <%= 'opacity-60' if transaction.pending? %>">
-  <% display_name = transaction.merchant_name.presence || transaction.name %>
+<% label = transaction.display_label(local_assigns[:transaction_name_overrides] || []) %>
+
+<%= link_to transaction_path(transaction),
+    id: dom_id(transaction),
+    class: "flex items-center justify-between gap-4 px-5 py-4 hover:bg-base-200 transition-colors #{transaction.pending? ? 'opacity-60' : ''}",
+    data: { turbo_frame: "transaction_detail", action: "click->drawer#open" } do %>
   <div class="flex items-center gap-3 min-w-0">
     <% if transaction.safe_logo_url %>
-      <img src="<%= transaction.safe_logo_url %>" alt="<%= display_name %>" class="h-10 w-10 rounded-full shrink-0" referrerpolicy="no-referrer" loading="lazy" />
+      <img src="<%= transaction.safe_logo_url %>" alt="<%= label %>" class="h-10 w-10 rounded-full shrink-0" referrerpolicy="no-referrer" loading="lazy" />
     <% else %>
       <div class="h-10 w-10 rounded-full bg-base-200 flex items-center justify-center shrink-0">
         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-base-content/40" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -12,7 +16,7 @@
     <% end %>
 
     <div class="min-w-0 flex items-center gap-1.5">
-      <p class="font-medium truncate"><%= display_name %></p>
+      <p class="font-medium truncate"><%= label %></p>
 
       <% if transaction.pending? %>
         <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 shrink-0 text-base-content/50" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -27,4 +31,4 @@
       <%= transaction.amount.negative? ? "+" : "" %><%= number_to_currency(transaction.amount.abs) %>
     </p>
   </div>
-</div>
+<% end %>

--- a/app/views/transactions/_transaction_detail.html.erb
+++ b/app/views/transactions/_transaction_detail.html.erb
@@ -6,11 +6,11 @@
   <%# Header %>
   <div class="flex items-center justify-between px-5 py-4 border-b border-base-300 shrink-0">
     <h2 class="font-semibold text-base">Transaction Details</h2>
-    <button class="btn btn-ghost btn-sm btn-circle" data-action="click->drawer#close">
+    <%= link_to transactions_path, class: "btn btn-ghost btn-sm btn-circle", data: { action: "click->drawer#close", turbo_frame: "_top" } do %>
       <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
       </svg>
-    </button>
+    <% end %>
   </div>
 
   <div class="overflow-y-auto flex-1 p-5 space-y-6">

--- a/app/views/transactions/_transaction_detail.html.erb
+++ b/app/views/transactions/_transaction_detail.html.erb
@@ -1,0 +1,146 @@
+<%# locals: (transaction:, transaction_name_override:) %>
+<% main_name = transaction_name_override ? transaction_name_override.replacement_name : (transaction.merchant_name.presence || transaction.name) %>
+<% show_original = main_name != transaction.name %>
+
+<div class="flex flex-col h-full">
+  <%# Header %>
+  <div class="flex items-center justify-between px-5 py-4 border-b border-base-300 shrink-0">
+    <h2 class="font-semibold text-base">Transaction Details</h2>
+    <button class="btn btn-ghost btn-sm btn-circle" data-action="click->drawer#close">
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+      </svg>
+    </button>
+  </div>
+
+  <div class="overflow-y-auto flex-1 p-5 space-y-6">
+    <%# Identity %>
+    <div class="flex items-start gap-4">
+      <% if transaction.safe_logo_url %>
+        <img src="<%= transaction.safe_logo_url %>" alt="<%= main_name %>" class="h-14 w-14 rounded-full shrink-0" referrerpolicy="no-referrer" loading="lazy" />
+      <% else %>
+        <div class="h-14 w-14 rounded-full bg-base-200 flex items-center justify-center shrink-0">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-7 w-7 text-base-content/40" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" />
+          </svg>
+        </div>
+      <% end %>
+
+      <div class="min-w-0 flex-1" data-controller="toggle" data-toggle-delay-frame-value="transaction_detail">
+        <div class="flex items-center gap-1.5">
+          <h3 class="text-xl font-bold leading-tight truncate"><%= main_name %></h3>
+          <button data-action="toggle#toggle" class="btn btn-ghost btn-xs btn-circle shrink-0 text-primary hover:text-primary" title="Edit name">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+            </svg>
+          </button>
+        </div>
+        <% if show_original %>
+          <p class="text-sm text-base-content/50 mt-0.5 truncate"><%= transaction.name %></p>
+        <% end %>
+
+        <div data-toggle-target="content" class="hidden mt-3">
+          <% if transaction_name_override %>
+            <div class="bg-base-200 rounded-xl p-3">
+              <div class="flex items-center justify-between gap-3">
+                <div class="text-sm">
+                  <span class="badge badge-sm <%= transaction_name_override.match_type == "exact" ? "badge-primary" : "badge-secondary" %> mr-1">
+                    <%= transaction_name_override.match_type == "exact" ? "Exact" : "Contains" %>
+                  </span>
+                  "<%= transaction_name_override.match_text %>"
+                  <span class="text-base-content/40 mx-1">→</span>
+                  "<%= transaction_name_override.replacement_name %>"
+                </div>
+                <%= button_to transaction_name_override_path(transaction_name_override),
+                    method: :delete,
+                    params: { transaction_id: transaction.id },
+                    class: "btn btn-ghost btn-sm text-error shrink-0",
+                    data: { controller: "loading-button", loading_button_text_value: "" },
+                    form: { data: { action: "submit->toggle#close" } } do %>
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  </svg>
+                <% end %>
+              </div>
+            </div>
+          <% else %>
+            <% if transaction.merchant_name.present? %>
+              <p class="text-xs text-base-content/50 mb-3">"<%= transaction.merchant_name %>" was automatically set by your bank. Set an override below to rename it.</p>
+            <% end %>
+
+            <%= form_with url: transaction_name_overrides_path, scope: :transaction_name_override, data: { action: "submit->toggle#close" } do |f| %>
+              <%= hidden_field_tag :transaction_id, transaction.id %>
+
+              <div class="flex gap-4 mb-3">
+                <%= render "components/radio_button", form: f, field: :match_type, value: "exact", label: "Exact match", checked: true %>
+                <%= render "components/radio_button", form: f, field: :match_type, value: "contains", label: "Contains" %>
+              </div>
+
+              <div class="space-y-2 mb-3">
+                <div>
+                  <label class="label py-0 mb-1"><span class="label-text text-xs text-base-content/60">Match text</span></label>
+                  <%= f.text_field :match_text, value: transaction.name, class: "input input-bordered input-sm w-full" %>
+                </div>
+                <div>
+                  <label class="label py-0 mb-1"><span class="label-text text-xs text-base-content/60">Rename to</span></label>
+                  <%= f.text_field :replacement_name, class: "input input-bordered input-sm w-full", placeholder: "New display name" %>
+                </div>
+              </div>
+
+              <div class="flex gap-2">
+                <%= f.button "Save", type: "submit", class: "btn btn-primary btn-sm flex-1", data: { controller: "loading-button", loading_button_text_value: "Saving..." } %>
+                <button type="button" data-action="toggle#toggle" class="btn btn-ghost btn-sm flex-1">Cancel</button>
+              </div>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+
+    <%# Amount %>
+    <div class="text-3xl font-bold <%= transaction.amount.negative? ? 'text-success' : 'text-error' %>">
+      <%= transaction.amount.negative? ? "+" : "" %><%= number_to_currency(transaction.amount.abs) %>
+      <% if transaction.pending? %>
+        <span class="text-base font-normal text-base-content/50 ml-1">Pending</span>
+      <% end %>
+    </div>
+
+    <%# Details %>
+    <div class="space-y-3 text-sm">
+      <% if transaction.date %>
+        <div class="flex justify-between gap-4">
+          <span class="text-base-content/50">Date</span>
+          <span class="font-medium text-right"><%= transaction.date.strftime("%B %-d, %Y") %></span>
+        </div>
+      <% end %>
+
+      <% if transaction.merchant_name.present? && transaction.merchant_name != transaction.name %>
+        <div class="flex justify-between gap-4">
+          <span class="text-base-content/50">Merchant</span>
+          <span class="font-medium text-right"><%= transaction.merchant_name %></span>
+        </div>
+      <% end %>
+
+      <% if transaction.personal_finance_category.present? %>
+        <div class="flex justify-between gap-4">
+          <span class="text-base-content/50">Category</span>
+          <span class="font-medium text-right"><%= transaction.personal_finance_category.gsub("_", " ").titleize %></span>
+        </div>
+      <% end %>
+
+      <% if transaction.payment_channel.present? %>
+        <div class="flex justify-between gap-4">
+          <span class="text-base-content/50">Channel</span>
+          <span class="font-medium text-right"><%= transaction.payment_channel.gsub("_", " ").titleize %></span>
+        </div>
+      <% end %>
+
+      <% if transaction.bank_account %>
+        <div class="flex justify-between gap-4">
+          <span class="text-base-content/50">Account</span>
+          <span class="font-medium text-right"><%= transaction.bank_account.name %></span>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/transactions/index.html.erb
+++ b/app/views/transactions/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "Transactions" %>
 
-<div class="flex flex-col items-center pb-10">
+<div class="flex flex-col items-center pb-10" data-controller="drawer">
   <h2 class="text-2xl font-bold mt-10 w-full max-w-240 px-4">Transactions</h2>
 
   <% if @transactions.any? %>
@@ -22,7 +22,7 @@
           <div class="card bg-base-100 shadow-glow">
             <div class="card-body p-0 gap-0 divide-y divide-base-300">
               <% transactions.each do |transaction| %>
-                <%= render transaction %>
+                <%= render transaction, transaction_name_overrides: @transaction_name_overrides %>
               <% end %>
             </div>
           </div>
@@ -60,4 +60,17 @@
       </div>
     </div>
   <% end %>
+
+  <%# Drawer overlay %>
+  <div data-drawer-target="overlay"
+       class="fixed inset-0 bg-black/50 z-40 opacity-0 pointer-events-none transition-opacity duration-300"
+       data-action="click->drawer#close">
+  </div>
+
+  <%# Drawer panel %>
+  <div data-drawer-target="panel"
+       class="fixed inset-y-0 right-0 z-50 w-full max-w-md bg-base-100 shadow-2xl transform translate-x-full transition-transform duration-300 flex flex-col">
+    <%= turbo_frame_tag "transaction_detail" do %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -1,0 +1,7 @@
+<% content_for :title, "Transaction" %>
+
+<%= turbo_frame_tag "transaction_detail" do %>
+  <%= render "transactions/transaction_detail",
+      transaction: @transaction,
+      transaction_name_override: @transaction_name_override %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,8 @@ Rails.application.routes.draw do
   resource :session
   resources :passwords, param: :token
   resources :users, only: [ :new, :create ]
-  resources :transactions, only: [ :index ]
+  resources :transactions, only: [ :index, :show ]
+  resources :transaction_name_overrides, only: [ :create, :destroy ]
   resources :expenses, only: [ :index ]
   resources :goals, only: [ :index ]
   resource :profile, only: [ :show, :edit, :update ] do

--- a/db/migrate/20260608120000_create_transaction_name_overrides.rb
+++ b/db/migrate/20260608120000_create_transaction_name_overrides.rb
@@ -1,0 +1,14 @@
+class CreateTransactionNameOverrides < ActiveRecord::Migration[8.1]
+  def change
+    create_table :transaction_name_overrides, id: :uuid do |t|
+      t.references :user, null: false, foreign_key: true, type: :uuid
+      t.string :match_type, null: false
+      t.string :match_text, null: false
+      t.string :replacement_name, null: false
+
+      t.timestamps
+
+      t.index [ :user_id, :match_type, :match_text ], unique: true, name: 'index_transaction_name_overrides_uniqueness'
+    end
+  end
+end

--- a/db/migrate/20260608120000_create_transaction_name_overrides.rb
+++ b/db/migrate/20260608120000_create_transaction_name_overrides.rb
@@ -3,7 +3,7 @@ class CreateTransactionNameOverrides < ActiveRecord::Migration[8.1]
     create_table :transaction_name_overrides, id: :uuid do |t|
       t.references :user, null: false, foreign_key: true, type: :uuid
       t.string :match_type, null: false
-      t.string :match_text, null: false
+      t.citext :match_text, null: false
       t.string :replacement_name, null: false
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -215,7 +215,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_08_120000) do
 
   create_table "transaction_name_overrides", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.string "match_text", null: false
+    t.citext "match_text", null: false
     t.string "match_type", null: false
     t.string "replacement_name", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_06_203349) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_08_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -213,6 +213,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_06_203349) do
     t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
   end
 
+  create_table "transaction_name_overrides", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "match_text", null: false
+    t.string "match_type", null: false
+    t.string "replacement_name", null: false
+    t.datetime "updated_at", null: false
+    t.uuid "user_id", null: false
+    t.index ["user_id", "match_type", "match_text"], name: "index_transaction_name_overrides_uniqueness", unique: true
+    t.index ["user_id"], name: "index_transaction_name_overrides_on_user_id"
+  end
+
   create_table "transactions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.decimal "amount", precision: 10, scale: 2, null: false
     t.date "authorized_date"
@@ -267,5 +278,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_06_203349) do
   add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "transaction_name_overrides", "users"
   add_foreign_key "transactions", "bank_accounts"
 end

--- a/test/controllers/transaction_name_overrides_controller_test.rb
+++ b/test/controllers/transaction_name_overrides_controller_test.rb
@@ -92,7 +92,10 @@ class TransactionNameOverridesControllerTest < ActionDispatch::IntegrationTest
     matching = Transaction.create!(name: 'a freshmatch transaction', amount: 12.50, bank_account: bank_accounts(:chase_checking))
 
     post transaction_name_overrides_url,
-         params: { transaction_name_override: { match_type: 'contains', match_text: 'freshmatch', replacement_name: 'Renamed' } },
+         params: {
+           transaction_name_override: { match_type: 'contains', match_text: 'freshmatch', replacement_name: 'Renamed' },
+           transaction_id: matching.id
+         },
          headers: { Accept: 'text/vnd.turbo-stream.html' }
 
     assert_response :success

--- a/test/controllers/transaction_name_overrides_controller_test.rb
+++ b/test/controllers/transaction_name_overrides_controller_test.rb
@@ -87,6 +87,19 @@ class TransactionNameOverridesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to settings_path
   end
 
+  test 'create with contains match type updates matching transaction rows' do
+    sign_in_as(@user)
+    matching = Transaction.create!(name: 'a freshmatch transaction', amount: 12.50, bank_account: bank_accounts(:chase_checking))
+
+    post transaction_name_overrides_url,
+         params: { transaction_name_override: { match_type: 'contains', match_text: 'freshmatch', replacement_name: 'Renamed' } },
+         headers: { Accept: 'text/vnd.turbo-stream.html' }
+
+    assert_response :success
+    assert_match(/#{ActionView::RecordIdentifier.dom_id(matching)}/, response.body)
+    assert_match(/Renamed/, response.body)
+  end
+
   test 'safe_return_path rejects scheme-relative URLs' do
     sign_in_as(@user)
 

--- a/test/controllers/transaction_name_overrides_controller_test.rb
+++ b/test/controllers/transaction_name_overrides_controller_test.rb
@@ -1,0 +1,107 @@
+require 'test_helper'
+
+class TransactionNameOverridesControllerTest < ActionDispatch::IntegrationTest
+  setup { @user = users(:johndoe) }
+
+  test 'create requires authentication' do
+    post transaction_name_overrides_url, params: { transaction_name_override: { match_type: 'exact', match_text: 'AMAZON', replacement_name: 'Amazon' } }
+
+    assert_redirected_to new_session_path
+  end
+
+  test 'create persists the override' do
+    sign_in_as(@user)
+
+    assert_difference '@user.transaction_name_overrides.count', 1 do
+      post transaction_name_overrides_url,
+           params: { transaction_name_override: { match_type: 'exact', match_text: 'AMAZON', replacement_name: 'Amazon' } }
+    end
+
+    override = @user.transaction_name_overrides.order(:created_at).last
+    assert_equal 'exact', override.match_type
+    assert_equal 'AMAZON', override.match_text
+    assert_equal 'Amazon', override.replacement_name
+  end
+
+  test 'create responds with turbo_stream when requested' do
+    sign_in_as(@user)
+
+    post transaction_name_overrides_url,
+         params: { transaction_name_override: { match_type: 'exact', match_text: 'AMAZON', replacement_name: 'Amazon' } },
+         headers: { Accept: 'text/vnd.turbo-stream.html' }
+
+    assert_response :success
+    assert_equal 'text/vnd.turbo-stream.html; charset=utf-8', response.content_type
+  end
+
+  test 'create redirects with alert when invalid' do
+    sign_in_as(@user)
+
+    assert_no_difference '@user.transaction_name_overrides.count' do
+      post transaction_name_overrides_url, params: { transaction_name_override: { match_type: 'exact', match_text: '', replacement_name: 'Amazon' } }
+    end
+
+    assert_response :see_other
+    assert_match(/can't be blank/, flash[:alert])
+  end
+
+  test 'destroy removes the override' do
+    sign_in_as(@user)
+    override = transaction_name_overrides(:test_exact)
+
+    assert_difference '@user.transaction_name_overrides.count', -1 do
+      delete transaction_name_override_url(override),
+             headers: { Accept: 'text/vnd.turbo-stream.html' }
+    end
+
+    assert_response :success
+  end
+
+  test 'destroy with transaction_id includes drawer frame in stream' do
+    sign_in_as(@user)
+    override = transaction_name_overrides(:test_exact)
+    transaction = Transaction.create!(name: 'TESTEXACT', amount: 5.50, bank_account: bank_accounts(:chase_checking))
+
+    delete transaction_name_override_url(override),
+           params: { transaction_id: transaction.id },
+           headers: { Accept: 'text/vnd.turbo-stream.html' }
+
+    assert_response :success
+    assert_match(/transaction_detail/, response.body)
+  end
+
+  test 'destroy with missing record returns no_content for turbo_stream' do
+    sign_in_as(@user)
+
+    delete transaction_name_override_url('00000000-0000-0000-0000-000000000000'),
+           headers: { Accept: 'text/vnd.turbo-stream.html' }
+
+    assert_response :no_content
+  end
+
+  test 'destroy with missing record redirects to settings for html' do
+    sign_in_as(@user)
+
+    delete transaction_name_override_url('00000000-0000-0000-0000-000000000000')
+
+    assert_redirected_to settings_path
+  end
+
+  test 'safe_return_path rejects scheme-relative URLs' do
+    sign_in_as(@user)
+
+    post transaction_name_overrides_url,
+         params: { transaction_name_override: { match_type: 'exact', match_text: '', replacement_name: '' }, return_to: '//evil.com' }
+
+    assert_redirected_to settings_path
+  end
+
+  test 'safe_return_path accepts local paths' do
+    sign_in_as(@user)
+
+    post transaction_name_overrides_url,
+         params: { transaction_name_override: { match_type: 'exact', match_text: '', replacement_name: '' }, return_to: '/transactions' }
+
+    assert_redirected_to '/transactions'
+  end
+end

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -36,4 +36,42 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select 'p', text: 'No transactions yet'
   end
+
+  test 'index displays override name when an override matches' do
+    Transaction.create!(name: 'TESTEXACT', amount: 5.50, date: Date.current, bank_account: bank_accounts(:chase_checking))
+    sign_in_as(users(:johndoe))
+
+    get transactions_url
+
+    assert_response :success
+    assert_select 'p', text: 'ExactRenamed'
+  end
+
+  test 'show requires authentication' do
+    transaction = Transaction.create!(name: 'TESTEXACT', amount: 5.50, bank_account: bank_accounts(:chase_checking))
+
+    get transaction_url(transaction)
+
+    assert_redirected_to new_session_path
+  end
+
+  test 'show renders the transaction detail with applied override' do
+    transaction = Transaction.create!(name: 'TESTEXACT', amount: 5.50, bank_account: bank_accounts(:chase_checking))
+    sign_in_as(users(:johndoe))
+
+    get transaction_url(transaction)
+
+    assert_response :success
+    assert_select 'h3', text: 'ExactRenamed'
+  end
+
+  test 'show only finds transactions belonging to the current user' do
+    other_user_account = bank_accounts(:wells_checking)
+    transaction = Transaction.create!(name: 'Private', amount: 10.00, bank_account: other_user_account)
+    sign_in_as(users(:johndoe))
+
+    get transaction_url(transaction)
+
+    assert_response :not_found
+  end
 end

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -65,6 +65,16 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     assert_select 'h3', text: 'ExactRenamed'
   end
 
+  test 'show close button links back to transactions index' do
+    transaction = Transaction.create!(name: 'Standalone', amount: 5.00, bank_account: bank_accounts(:chase_checking))
+    sign_in_as(users(:johndoe))
+
+    get transaction_url(transaction)
+
+    assert_response :success
+    assert_select "a[href=\"#{transactions_path}\"][data-action='click->drawer#close']"
+  end
+
   test 'show only finds transactions belonging to the current user' do
     other_user_account = bank_accounts(:wells_checking)
     transaction = Transaction.create!(name: 'Private', amount: 10.00, bank_account: other_user_account)

--- a/test/fixtures/transaction_name_overrides.yml
+++ b/test/fixtures/transaction_name_overrides.yml
@@ -1,0 +1,11 @@
+test_exact:
+  user: johndoe
+  match_type: exact
+  match_text: TESTEXACT
+  replacement_name: ExactRenamed
+
+test_contains:
+  user: johndoe
+  match_type: contains
+  match_text: testcontains
+  replacement_name: ContainsRenamed

--- a/test/models/transaction_name_override_test.rb
+++ b/test/models/transaction_name_override_test.rb
@@ -1,0 +1,52 @@
+require 'test_helper'
+
+class TransactionNameOverrideTest < ActiveSupport::TestCase
+  setup { @user = users(:johndoe) }
+
+  test 'is valid with all required fields' do
+    override = @user.transaction_name_overrides.new(match_type: 'exact', match_text: 'AMAZON', replacement_name: 'Amazon')
+
+    assert override.valid?
+  end
+
+  test 'requires match_type to be exact or contains' do
+    override = @user.transaction_name_overrides.new(match_type: 'regex', match_text: 'AMAZON', replacement_name: 'Amazon')
+
+    assert_not override.valid?
+    assert_includes override.errors[:match_type], 'must be exact or contains'
+  end
+
+  test 'requires match_text' do
+    override = @user.transaction_name_overrides.new(match_type: 'exact', replacement_name: 'Amazon')
+
+    assert_not override.valid?
+    assert_includes override.errors[:match_text], "can't be blank"
+  end
+
+  test 'requires replacement_name' do
+    override = @user.transaction_name_overrides.new(match_type: 'exact', match_text: 'AMAZON')
+
+    assert_not override.valid?
+    assert_includes override.errors[:replacement_name], "can't be blank"
+  end
+
+  test 'enforces case-insensitive uniqueness scoped to user and match_type' do
+    duplicate = @user.transaction_name_overrides.new(match_type: 'exact', match_text: 'testexact', replacement_name: 'Other')
+
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:match_text], 'already has an override for this match type'
+  end
+
+  test 'allows same match_text for different match_type' do
+    override = @user.transaction_name_overrides.new(match_type: 'contains', match_text: 'TESTEXACT', replacement_name: 'Other')
+
+    assert override.valid?
+  end
+
+  test 'allows same match_text for different user' do
+    other_user = users(:janedoe)
+    override = other_user.transaction_name_overrides.new(match_type: 'exact', match_text: 'TESTEXACT', replacement_name: 'Other')
+
+    assert override.valid?
+  end
+end

--- a/test/models/transaction_test.rb
+++ b/test/models/transaction_test.rb
@@ -86,4 +86,60 @@ class TransactionTest < ActiveSupport::TestCase
 
     assert_nil transaction.safe_logo_url
   end
+
+  test 'display_name returns raw name when no overrides match' do
+    transaction = Transaction.new(name: 'AMAZON', amount: 10)
+    overrides = [ build_override('exact', 'STARBUCKS', 'Coffee') ]
+
+    assert_equal 'AMAZON', transaction.display_name(overrides)
+  end
+
+  test 'display_name returns override replacement on exact match (case-insensitive)' do
+    transaction = Transaction.new(name: 'starbucks', amount: 10)
+    overrides = [ build_override('exact', 'STARBUCKS', 'Coffee') ]
+
+    assert_equal 'Coffee', transaction.display_name(overrides)
+  end
+
+  test 'display_name returns override replacement on contains match (case-insensitive)' do
+    transaction = Transaction.new(name: 'Uber 072515 SF**POOL**', amount: 10)
+    overrides = [ build_override('contains', 'uber', 'Rideshare') ]
+
+    assert_equal 'Rideshare', transaction.display_name(overrides)
+  end
+
+  test 'applied_override prefers exact over contains when both match' do
+    transaction = Transaction.new(name: 'STARBUCKS Coffee', amount: 10)
+    contains_override = build_override('contains', 'starbucks', 'CoffeeShop')
+    exact_override = build_override('exact', 'STARBUCKS Coffee', 'Morning Coffee')
+    overrides = [ contains_override, exact_override ]
+
+    assert_equal exact_override, transaction.applied_override(overrides)
+    assert_equal 'Morning Coffee', transaction.display_name(overrides)
+  end
+
+  test 'display_label falls back to merchant_name when no override matches' do
+    transaction = Transaction.new(name: 'WHOLEFDS MKT #10', merchant_name: 'Whole Foods', amount: 10)
+
+    assert_equal 'Whole Foods', transaction.display_label([])
+  end
+
+  test 'display_label falls back to raw name when no override or merchant_name' do
+    transaction = Transaction.new(name: 'CASH WITHDRAWAL', amount: 10)
+
+    assert_equal 'CASH WITHDRAWAL', transaction.display_label([])
+  end
+
+  test 'display_label prefers override over merchant_name' do
+    transaction = Transaction.new(name: 'UBER', merchant_name: 'Uber', amount: 10)
+    overrides = [ build_override('exact', 'UBER', 'Rideshare') ]
+
+    assert_equal 'Rideshare', transaction.display_label(overrides)
+  end
+
+  private
+
+  def build_override(match_type, match_text, replacement_name)
+    TransactionNameOverride.new(match_type: match_type, match_text: match_text, replacement_name: replacement_name)
+  end
 end

--- a/test/services/push_notification_service_test.rb
+++ b/test/services/push_notification_service_test.rb
@@ -58,6 +58,45 @@ class PushNotificationServiceTest < ActiveSupport::TestCase
     assert_includes first_payload['body'], '$5.50'
   end
 
+  test 'uses override replacement_name in notification body when an override matches' do
+    payloads = []
+    WebPush.define_singleton_method(:payload_send) { |**args| payloads << args }
+
+    transactions = [ build_transaction('a testcontains transaction', 12.50) ]
+    PushNotificationService.notify_new_transactions(user: @user, transactions: transactions)
+
+    body = JSON.parse(payloads.first[:message])['body']
+    assert_includes body, 'ContainsRenamed'
+    assert_not_includes body, 'testcontains transaction'
+  end
+
+  test 'exact-match override takes priority over contains-match override' do
+    @user.transaction_name_overrides.create!(match_type: 'contains', match_text: 'priority', replacement_name: 'WrongPriority')
+    @user.transaction_name_overrides.create!(match_type: 'exact', match_text: 'PRIORITY', replacement_name: 'RightPriority')
+
+    payloads = []
+    WebPush.define_singleton_method(:payload_send) { |**args| payloads << args }
+
+    transactions = [ build_transaction('PRIORITY', 5.50) ]
+    PushNotificationService.notify_new_transactions(user: @user, transactions: transactions)
+
+    body = JSON.parse(payloads.first[:message])['body']
+    assert_includes body, 'RightPriority'
+    assert_not_includes body, 'WrongPriority'
+  end
+
+  test 'falls back to merchant_name when no override matches' do
+    payloads = []
+    WebPush.define_singleton_method(:payload_send) { |**args| payloads << args }
+
+    transactions = [ Transaction.new(id: SecureRandom.uuid, name: 'WHOLEFDS MKT #10', merchant_name: 'Whole Foods', amount: 50.00) ]
+    PushNotificationService.notify_new_transactions(user: @user, transactions: transactions)
+
+    body = JSON.parse(payloads.first[:message])['body']
+    assert_includes body, 'Whole Foods'
+    assert_not_includes body, 'WHOLEFDS'
+  end
+
   test 'sends summary notification for 6+ transactions' do
     payloads = []
     WebPush.define_singleton_method(:payload_send) { |**args| payloads << args }


### PR DESCRIPTION
## Summary

- Lets users define rename rules (exact or contains, case-insensitive) that apply to transactions whose raw name matches
- Overrides apply at display time, so the original Plaid name stays in the database — deleting a rule instantly reverts affected rows
- Manage overrides from the transaction detail drawer (opened by clicking a row in the list) or delete them from the settings page
- Push notifications and the transactions list both use the override name when one applies, with `merchant_name` as the fallback

## Implementation notes

- New `TransactionNameOverride` model with `exact` and `contains` match types; exact takes priority. Uniqueness scoped per user + match_type + match_text (case-insensitive)
- `Transaction#display_name` / `#display_label` apply rules in views and the push notification service
- Drawer is a slide-over panel powered by a `drawer` Stimulus controller, with a Turbo Frame inside for lazy-loaded details
- Override save/delete responses use Turbo Streams to update the affected transaction rows AND the drawer frame in one shot — the drawer stays open and never reloads the page
- A `toggle` Stimulus controller animates the override edit panel open/closed and delays Turbo Stream renders until the close animation finishes
- A `dismissible` Stimulus controller animates settings-page overrides out and reveals an empty-state sibling when the last item is removed
- New `_radio_button.html.erb` component extracted from the duplicated radio markup

## Test plan

- [ ] Create an exact-match override from the transaction drawer → drawer shows the new override, matching rows in the list update without page reload
- [ ] Create a contains-match override (e.g. "fun" → "Funny") → all transactions whose raw name contains "fun" (case-insensitive) display the new name
- [ ] Have both an exact and contains rule match the same transaction → exact wins
- [ ] Delete an override from the drawer → drawer updates to the create form, transaction names revert in the list
- [ ] Delete an override from the settings page → row animates out, empty state appears when last row is removed
- [ ] Save/delete with browser dev tools network throttling → animations complete before the new content appears
- [ ] Trigger a push notification for a transaction that matches an override → notification body shows the override name

🤖 Generated with [Claude Code](https://claude.com/claude-code)