### PR TITLE
Fix drawer not blocking navbar taps on iOS

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -72,7 +72,7 @@
     <%# Drawer panel %>
     <div data-drawer-target="panel"
          class="fixed inset-y-0 right-0 z-50 w-full max-w-md bg-base-100 shadow-2xl transform translate-x-full transition-transform duration-300 flex flex-col">
-      <%= turbo_frame_tag "transaction_detail" %>
+      <%= turbo_frame_tag "drawer_content" %>
     </div>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -45,7 +45,7 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
-  <body class="h-dvh flex flex-col overflow-hidden">
+  <body class="h-dvh flex flex-col overflow-hidden" data-controller="drawer">
     <%= render "components/top_navigation" unless authentication_page? %>
 
     <main class="relative flex-1 overflow-y-auto overscroll-contain <%= 'touch-action-pan-y' if swipe_nav? %>"
@@ -62,5 +62,17 @@
     </main>
 
     <%= render "components/bottom_navigation" unless authentication_page? %>
+
+    <%# Drawer overlay (slide-over for transaction detail and similar) %>
+    <div data-drawer-target="overlay"
+         class="fixed inset-0 bg-black/50 z-40 opacity-0 pointer-events-none transition-opacity duration-300 cursor-pointer"
+         data-action="click->drawer#close">
+    </div>
+
+    <%# Drawer panel %>
+    <div data-drawer-target="panel"
+         class="fixed inset-y-0 right-0 z-50 w-full max-w-md bg-base-100 shadow-2xl transform translate-x-full transition-transform duration-300 flex flex-col">
+      <%= turbo_frame_tag "transaction_detail" %>
+    </div>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -72,7 +72,9 @@
     <%# Drawer panel %>
     <div data-drawer-target="panel"
          class="fixed inset-y-0 right-0 z-50 w-full max-w-md bg-base-100 shadow-2xl transform translate-x-full transition-transform duration-300 flex flex-col">
-      <%= turbo_frame_tag "drawer_content" %>
+      <% unless content_for?(:drawer_frame_provided) %>
+        <%= turbo_frame_tag "drawer_content" %>
+      <% end %>
     </div>
   </body>
 </html>

--- a/app/views/transaction_name_overrides/create.turbo_stream.erb
+++ b/app/views/transaction_name_overrides/create.turbo_stream.erb
@@ -5,8 +5,8 @@
     <% end %>
   <% end %>
 
-  <%= turbo_stream.replace "transaction_detail" do %>
-    <%= turbo_frame_tag "transaction_detail" do %>
+  <%= turbo_stream.replace "drawer_content" do %>
+    <%= turbo_frame_tag "drawer_content" do %>
       <%= render "transactions/transaction_detail",
           transaction: @transaction,
           transaction_name_override: @transaction_name_override %>

--- a/app/views/transaction_name_overrides/destroy.turbo_stream.erb
+++ b/app/views/transaction_name_overrides/destroy.turbo_stream.erb
@@ -5,8 +5,8 @@
     <% end %>
   <% end %>
 
-  <%= turbo_stream.replace "transaction_detail" do %>
-    <%= turbo_frame_tag "transaction_detail" do %>
+  <%= turbo_stream.replace "drawer_content" do %>
+    <%= turbo_frame_tag "drawer_content" do %>
       <%= render "transactions/transaction_detail",
           transaction: @transaction,
           transaction_name_override: @transaction_name_override %>

--- a/app/views/transactions/_transaction.html.erb
+++ b/app/views/transactions/_transaction.html.erb
@@ -3,7 +3,7 @@
 <%= link_to transaction_path(transaction),
     id: dom_id(transaction),
     class: "flex items-center justify-between gap-4 px-5 py-4 hover:bg-base-200 transition-colors #{transaction.pending? ? 'opacity-60' : ''}",
-    data: { turbo_frame: "transaction_detail", action: "click->drawer#open" } do %>
+    data: { turbo_frame: "drawer_content", action: "click->drawer#open" } do %>
   <div class="flex items-center gap-3 min-w-0">
     <% if transaction.safe_logo_url %>
       <img src="<%= transaction.safe_logo_url %>" alt="<%= label %>" class="h-10 w-10 rounded-full shrink-0" referrerpolicy="no-referrer" loading="lazy" />

--- a/app/views/transactions/_transaction_detail.html.erb
+++ b/app/views/transactions/_transaction_detail.html.erb
@@ -26,7 +26,7 @@
         </div>
       <% end %>
 
-      <div class="min-w-0 flex-1" data-controller="toggle" data-toggle-delay-frame-value="transaction_detail">
+      <div class="min-w-0 flex-1" data-controller="toggle" data-toggle-delay-frame-value="drawer_content">
         <div class="flex items-center gap-1.5">
           <h3 class="text-xl font-bold leading-tight truncate"><%= main_name %></h3>
           <button data-action="toggle#toggle" class="btn btn-ghost btn-xs btn-circle shrink-0 text-primary hover:text-primary" title="Edit name">

--- a/app/views/transactions/index.html.erb
+++ b/app/views/transactions/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "Transactions" %>
 
-<div class="flex flex-col items-center pb-10" data-controller="drawer">
+<div class="flex flex-col items-center pb-10">
   <h2 class="text-2xl font-bold mt-10 w-full max-w-240 px-4">Transactions</h2>
 
   <% if @transactions.any? %>
@@ -61,16 +61,4 @@
     </div>
   <% end %>
 
-  <%# Drawer overlay %>
-  <div data-drawer-target="overlay"
-       class="fixed inset-0 bg-black/50 z-40 opacity-0 pointer-events-none transition-opacity duration-300"
-       data-action="click->drawer#close">
-  </div>
-
-  <%# Drawer panel %>
-  <div data-drawer-target="panel"
-       class="fixed inset-y-0 right-0 z-50 w-full max-w-md bg-base-100 shadow-2xl transform translate-x-full transition-transform duration-300 flex flex-col">
-    <%= turbo_frame_tag "transaction_detail" do %>
-    <% end %>
-  </div>
 </div>

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, "Transaction" %>
+<% content_for :drawer_frame_provided, true %>
 
 <%= turbo_frame_tag "drawer_content" do %>
   <%= render "transactions/transaction_detail",

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "Transaction" %>
 
-<%= turbo_frame_tag "transaction_detail" do %>
+<%= turbo_frame_tag "drawer_content" do %>
   <%= render "transactions/transaction_detail",
       transaction: @transaction,
       transaction_name_override: @transaction_name_override %>

--- a/test/controllers/transaction_name_overrides_controller_test.rb
+++ b/test/controllers/transaction_name_overrides_controller_test.rb
@@ -67,7 +67,7 @@ class TransactionNameOverridesControllerTest < ActionDispatch::IntegrationTest
            headers: { Accept: 'text/vnd.turbo-stream.html' }
 
     assert_response :success
-    assert_match(/transaction_detail/, response.body)
+    assert_match(/drawer_content/, response.body)
   end
 
   test 'destroy with missing record returns no_content for turbo_stream' do

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -65,6 +65,25 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     assert_select 'h3', text: 'ExactRenamed'
   end
 
+  test 'show does not render a duplicate drawer_content frame in the layout' do
+    transaction = Transaction.create!(name: 'Solo', amount: 10.00, bank_account: bank_accounts(:chase_checking))
+    sign_in_as(users(:johndoe))
+
+    get transaction_url(transaction)
+
+    assert_response :success
+    assert_select 'turbo-frame[id=drawer_content]', count: 1
+  end
+
+  test 'index renders an empty drawer_content frame in the layout' do
+    sign_in_as(users(:johndoe))
+
+    get transactions_url
+
+    assert_response :success
+    assert_select 'turbo-frame[id=drawer_content]', count: 1
+  end
+
   test 'show close button links back to transactions index' do
     transaction = Transaction.create!(name: 'Standalone', amount: 5.00, bank_account: bank_accounts(:chase_checking))
     sign_in_as(users(:johndoe))


### PR DESCRIPTION
## Summary

On iOS Safari, taps on the transaction drawer's overlay were falling through to the avatar in the top navbar (briefly flashing the dropdown menu) instead of closing the drawer.

**Root cause:** iOS Safari positions \`position: fixed\` elements relative to the nearest \`overflow-y-auto\` ancestor, not the viewport. The drawer overlay was inside \`<main>\` (which has \`overflow-y-auto\` for the scroll container + pull-to-refresh), so it only covered \`<main>\` — leaving the navbar exposed to taps.

**Fix:** Moved the drawer (controller, overlay, panel, and \`transaction_detail\` Turbo Frame) to the layout as a sibling of \`<main>\`. The overlay now covers the entire viewport on iOS. Also added \`cursor-pointer\` to the overlay so iOS reliably registers click events on the bare div.

## Test plan

- [ ] On iOS Safari: open a transaction → tap the dimmed area outside the drawer → drawer closes
- [ ] On iOS Safari: tap on the avatar area while drawer is open → drawer closes, dropdown does NOT open
- [ ] Desktop: drawer behavior unchanged (open, close via overlay, close via X)
- [ ] Standalone \`/transactions/:id\` (no drawer) still renders correctly with the link-back close button

🤖 Generated with [Claude Code](https://claude.com/claude-code)