### PR TITLE
Paginate transaction name overrides on settings page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,9 @@ gem 'mission_control-jobs'
 # A ruby implementation of the RFC 7519 OAuth JSON Web Token standard. [https://github.com/jwt/ruby-jwt]
 gem 'jwt'
 
+# Pagination [https://github.com/ddnexus/pagy]
+gem 'pagy', '~> 9.0'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: [ :mri, :windows ], require: 'debug/prelude'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,6 +236,7 @@ GEM
       racc (~> 1.4)
     openssl (4.0.1)
     ostruct (0.6.3)
+    pagy (9.4.0)
     paper_trail (17.0.0)
       activerecord (>= 7.1)
       request_store (~> 1.4)
@@ -453,6 +454,7 @@ DEPENDENCIES
   mjml-rails
   mrml
   ostruct
+  pagy (~> 9.0)
   paper_trail
   pg (~> 1.1)
   plaid

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   include Authentication
+  include Pagy::Backend
 
   before_action :set_paper_trail_whodunnit
 

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,8 +1,18 @@
 class SettingsController < ApplicationController
+  TRANSACTION_NAME_OVERRIDES_PER_PAGE = 5
+
   def show
     @bank = Current.user.banks.includes(:bank_accounts).first
     @push_notifications_enabled = Current.user.push_subscriptions.exists?
-    @transaction_name_overrides = Current.user.transaction_name_overrides.order(:match_type, :match_text).to_a
+
+    overrides_scope = Current.user.transaction_name_overrides.order(:match_type, :match_text)
+    @transaction_name_overrides_total = overrides_scope.count
+    @transaction_name_overrides_total_pages = [ (@transaction_name_overrides_total.to_f / TRANSACTION_NAME_OVERRIDES_PER_PAGE).ceil, 1 ].max
+    @transaction_name_overrides_page = params[:page].to_i.clamp(1, @transaction_name_overrides_total_pages)
+    @transaction_name_overrides = overrides_scope
+                                  .limit(TRANSACTION_NAME_OVERRIDES_PER_PAGE)
+                                  .offset((@transaction_name_overrides_page - 1) * TRANSACTION_NAME_OVERRIDES_PER_PAGE)
+                                  .to_a
 
     if @bank
       if @bank.needs_attention? && !@bank.disconnected?

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -4,7 +4,8 @@ class SettingsController < ApplicationController
     @push_notifications_enabled = Current.user.push_subscriptions.exists?
 
     @transaction_name_overrides_pagy, @transaction_name_overrides = pagy(
-      Current.user.transaction_name_overrides.order(:match_type, :match_text)
+      Current.user.transaction_name_overrides.order(:match_type, :match_text),
+      limit: 5
     )
 
     if @bank

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,18 +1,11 @@
 class SettingsController < ApplicationController
-  TRANSACTION_NAME_OVERRIDES_PER_PAGE = 5
-
   def show
     @bank = Current.user.banks.includes(:bank_accounts).first
     @push_notifications_enabled = Current.user.push_subscriptions.exists?
 
-    overrides_scope = Current.user.transaction_name_overrides.order(:match_type, :match_text)
-    @transaction_name_overrides_total = overrides_scope.count
-    @transaction_name_overrides_total_pages = [ (@transaction_name_overrides_total.to_f / TRANSACTION_NAME_OVERRIDES_PER_PAGE).ceil, 1 ].max
-    @transaction_name_overrides_page = params[:page].to_i.clamp(1, @transaction_name_overrides_total_pages)
-    @transaction_name_overrides = overrides_scope
-                                  .limit(TRANSACTION_NAME_OVERRIDES_PER_PAGE)
-                                  .offset((@transaction_name_overrides_page - 1) * TRANSACTION_NAME_OVERRIDES_PER_PAGE)
-                                  .to_a
+    @transaction_name_overrides_pagy, @transaction_name_overrides = pagy(
+      Current.user.transaction_name_overrides.order(:match_type, :match_text)
+    )
 
     if @bank
       if @bank.needs_attention? && !@bank.disconnected?

--- a/app/controllers/transaction_name_overrides_controller.rb
+++ b/app/controllers/transaction_name_overrides_controller.rb
@@ -28,8 +28,16 @@ class TransactionNameOverridesController < ApplicationController
   def destroy
     @matching_transactions = matching_transactions(@override) if params[:transaction_id].present?
     @override.destroy
-    @transaction_name_overrides = Current.user.transaction_name_overrides.to_a
-    load_transaction_for_drawer
+
+    if params[:transaction_id].present?
+      @transaction_name_overrides = Current.user.transaction_name_overrides.to_a
+      load_transaction_for_drawer
+    else
+      @transaction_name_overrides_pagy, @transaction_name_overrides = pagy(
+        Current.user.transaction_name_overrides.order(:match_type, :match_text),
+        request_path: settings_path
+      )
+    end
 
     respond_to do |format|
       format.turbo_stream

--- a/app/controllers/transaction_name_overrides_controller.rb
+++ b/app/controllers/transaction_name_overrides_controller.rb
@@ -35,6 +35,7 @@ class TransactionNameOverridesController < ApplicationController
     else
       @transaction_name_overrides_pagy, @transaction_name_overrides = pagy(
         Current.user.transaction_name_overrides.order(:match_type, :match_text),
+        limit: 5,
         request_path: settings_path
       )
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,6 @@
 module ApplicationHelper
+  include Pagy::Frontend
+
   def authentication_page?
     controller_name == 'sessions' ||
       (controller_name == 'users' && action_name == 'new') ||

--- a/app/javascript/controllers/dismissible_controller.js
+++ b/app/javascript/controllers/dismissible_controller.js
@@ -34,8 +34,7 @@ export default class extends Controller {
       .filter(el => el !== this.element)
     if (remaining.length === 0) {
       const empty = parent.querySelector("[data-empty-state]")
-      // Skip if there are other pages — the local DOM count doesn't reflect the global state
-      if (empty && empty.dataset.multiPage !== "true") empty.classList.remove("hidden")
+      if (empty) empty.classList.remove("hidden")
     }
   }
 

--- a/app/javascript/controllers/dismissible_controller.js
+++ b/app/javascript/controllers/dismissible_controller.js
@@ -34,7 +34,8 @@ export default class extends Controller {
       .filter(el => el !== this.element)
     if (remaining.length === 0) {
       const empty = parent.querySelector("[data-empty-state]")
-      if (empty) empty.classList.remove("hidden")
+      // Skip if there are other pages — the local DOM count doesn't reflect the global state
+      if (empty && empty.dataset.multiPage !== "true") empty.classList.remove("hidden")
     }
   }
 

--- a/app/views/components/_pagination.html.erb
+++ b/app/views/components/_pagination.html.erb
@@ -1,0 +1,29 @@
+<%# locals: (pagy:) %>
+
+<% if pagy.pages > 1 %>
+  <div class="flex items-center justify-between mt-4 pt-4 border-t border-base-300">
+    <% if pagy.prev %>
+      <%= link_to pagy_url_for(pagy, pagy.prev), class: "btn btn-ghost btn-sm" do %>
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+        </svg>
+        Prev
+      <% end %>
+    <% else %>
+      <span></span>
+    <% end %>
+
+    <span class="text-sm text-base-content/60">Page <%= pagy.page %> of <%= pagy.pages %></span>
+
+    <% if pagy.next %>
+      <%= link_to pagy_url_for(pagy, pagy.next), class: "btn btn-ghost btn-sm" do %>
+        Next
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+        </svg>
+      <% end %>
+    <% else %>
+      <span></span>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/settings/_transaction_name_overrides.html.erb
+++ b/app/views/settings/_transaction_name_overrides.html.erb
@@ -8,38 +8,12 @@
         <% @transaction_name_overrides.each do |override| %>
           <%= render override %>
         <% end %>
-        <p data-empty-state class="text-sm text-base-content/40 text-center py-6 <%= 'hidden' if @transaction_name_overrides_total.positive? %>">
+        <p data-empty-state class="text-sm text-base-content/40 text-center py-6 <%= 'hidden' if @transaction_name_overrides_pagy.count.positive? %>">
           No overrides yet. Edit a transaction name to add one.
         </p>
       </div>
 
-      <% if @transaction_name_overrides_total_pages > 1 %>
-        <div class="flex items-center justify-between mt-4 pt-4 border-t border-base-300">
-          <% if @transaction_name_overrides_page > 1 %>
-            <%= link_to settings_path(page: @transaction_name_overrides_page - 1), class: "btn btn-ghost btn-sm" do %>
-              <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
-              </svg>
-              Prev
-            <% end %>
-          <% else %>
-            <span></span>
-          <% end %>
-
-          <span class="text-sm text-base-content/60">Page <%= @transaction_name_overrides_page %> of <%= @transaction_name_overrides_total_pages %></span>
-
-          <% if @transaction_name_overrides_page < @transaction_name_overrides_total_pages %>
-            <%= link_to settings_path(page: @transaction_name_overrides_page + 1), class: "btn btn-ghost btn-sm" do %>
-              Next
-              <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-              </svg>
-            <% end %>
-          <% else %>
-            <span></span>
-          <% end %>
-        </div>
-      <% end %>
+      <%= render "components/pagination", pagy: @transaction_name_overrides_pagy %>
     <% end %>
   </div>
 </div>

--- a/app/views/settings/_transaction_name_overrides.html.erb
+++ b/app/views/settings/_transaction_name_overrides.html.erb
@@ -7,9 +7,37 @@
       <% @transaction_name_overrides.each do |override| %>
         <%= render override %>
       <% end %>
-      <p data-empty-state class="text-sm text-base-content/40 text-center py-6 <%= 'hidden' if @transaction_name_overrides.any? %>">
+      <p data-empty-state class="text-sm text-base-content/40 text-center py-6 <%= 'hidden' if @transaction_name_overrides_total.positive? %>">
         No overrides yet. Edit a transaction name to add one.
       </p>
     </div>
+
+    <% if @transaction_name_overrides_total_pages > 1 %>
+      <div class="flex items-center justify-between mt-4 pt-4 border-t border-base-300">
+        <% if @transaction_name_overrides_page > 1 %>
+          <%= link_to settings_path(page: @transaction_name_overrides_page - 1), class: "btn btn-ghost btn-sm" do %>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+            </svg>
+            Prev
+          <% end %>
+        <% else %>
+          <span></span>
+        <% end %>
+
+        <span class="text-sm text-base-content/60">Page <%= @transaction_name_overrides_page %> of <%= @transaction_name_overrides_total_pages %></span>
+
+        <% if @transaction_name_overrides_page < @transaction_name_overrides_total_pages %>
+          <%= link_to settings_path(page: @transaction_name_overrides_page + 1), class: "btn btn-ghost btn-sm" do %>
+            Next
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+          <% end %>
+        <% else %>
+          <span></span>
+        <% end %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/settings/_transaction_name_overrides.html.erb
+++ b/app/views/settings/_transaction_name_overrides.html.erb
@@ -4,17 +4,9 @@
     <p class="text-sm text-base-content/60 mt-1">Automatically rename transactions based on matching rules. Exact match takes priority over contains.</p>
 
     <%= turbo_frame_tag "transaction_name_overrides" do %>
-      <% multi_page = @transaction_name_overrides_pagy.pages > 1 %>
-      <div class="space-y-2 mt-2">
-        <% @transaction_name_overrides.each do |override| %>
-          <%= render override %>
-        <% end %>
-        <p data-empty-state <%= 'data-multi-page=true'.html_safe if multi_page %> class="text-sm text-base-content/40 text-center py-6 <%= 'hidden' if @transaction_name_overrides_pagy.count.positive? %>">
-          No overrides yet. Edit a transaction name to add one.
-        </p>
-      </div>
-
-      <%= render "components/pagination", pagy: @transaction_name_overrides_pagy %>
+      <%= render "transaction_name_overrides/list",
+          transaction_name_overrides: @transaction_name_overrides,
+          transaction_name_overrides_pagy: @transaction_name_overrides_pagy %>
     <% end %>
   </div>
 </div>

--- a/app/views/settings/_transaction_name_overrides.html.erb
+++ b/app/views/settings/_transaction_name_overrides.html.erb
@@ -3,41 +3,43 @@
     <h2 class="card-title">Transaction Name Overrides</h2>
     <p class="text-sm text-base-content/60 mt-1">Automatically rename transactions based on matching rules. Exact match takes priority over contains.</p>
 
-    <div class="space-y-2 mt-2">
-      <% @transaction_name_overrides.each do |override| %>
-        <%= render override %>
-      <% end %>
-      <p data-empty-state class="text-sm text-base-content/40 text-center py-6 <%= 'hidden' if @transaction_name_overrides_total.positive? %>">
-        No overrides yet. Edit a transaction name to add one.
-      </p>
-    </div>
-
-    <% if @transaction_name_overrides_total_pages > 1 %>
-      <div class="flex items-center justify-between mt-4 pt-4 border-t border-base-300">
-        <% if @transaction_name_overrides_page > 1 %>
-          <%= link_to settings_path(page: @transaction_name_overrides_page - 1), class: "btn btn-ghost btn-sm" do %>
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
-            </svg>
-            Prev
-          <% end %>
-        <% else %>
-          <span></span>
+    <%= turbo_frame_tag "transaction_name_overrides" do %>
+      <div class="space-y-2 mt-2">
+        <% @transaction_name_overrides.each do |override| %>
+          <%= render override %>
         <% end %>
-
-        <span class="text-sm text-base-content/60">Page <%= @transaction_name_overrides_page %> of <%= @transaction_name_overrides_total_pages %></span>
-
-        <% if @transaction_name_overrides_page < @transaction_name_overrides_total_pages %>
-          <%= link_to settings_path(page: @transaction_name_overrides_page + 1), class: "btn btn-ghost btn-sm" do %>
-            Next
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-            </svg>
-          <% end %>
-        <% else %>
-          <span></span>
-        <% end %>
+        <p data-empty-state class="text-sm text-base-content/40 text-center py-6 <%= 'hidden' if @transaction_name_overrides_total.positive? %>">
+          No overrides yet. Edit a transaction name to add one.
+        </p>
       </div>
+
+      <% if @transaction_name_overrides_total_pages > 1 %>
+        <div class="flex items-center justify-between mt-4 pt-4 border-t border-base-300">
+          <% if @transaction_name_overrides_page > 1 %>
+            <%= link_to settings_path(page: @transaction_name_overrides_page - 1), class: "btn btn-ghost btn-sm" do %>
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+              </svg>
+              Prev
+            <% end %>
+          <% else %>
+            <span></span>
+          <% end %>
+
+          <span class="text-sm text-base-content/60">Page <%= @transaction_name_overrides_page %> of <%= @transaction_name_overrides_total_pages %></span>
+
+          <% if @transaction_name_overrides_page < @transaction_name_overrides_total_pages %>
+            <%= link_to settings_path(page: @transaction_name_overrides_page + 1), class: "btn btn-ghost btn-sm" do %>
+              Next
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+              </svg>
+            <% end %>
+          <% else %>
+            <span></span>
+          <% end %>
+        </div>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/settings/_transaction_name_overrides.html.erb
+++ b/app/views/settings/_transaction_name_overrides.html.erb
@@ -4,11 +4,12 @@
     <p class="text-sm text-base-content/60 mt-1">Automatically rename transactions based on matching rules. Exact match takes priority over contains.</p>
 
     <%= turbo_frame_tag "transaction_name_overrides" do %>
+      <% multi_page = @transaction_name_overrides_pagy.pages > 1 %>
       <div class="space-y-2 mt-2">
         <% @transaction_name_overrides.each do |override| %>
           <%= render override %>
         <% end %>
-        <p data-empty-state class="text-sm text-base-content/40 text-center py-6 <%= 'hidden' if @transaction_name_overrides_pagy.count.positive? %>">
+        <p data-empty-state <%= 'data-multi-page=true'.html_safe if multi_page %> class="text-sm text-base-content/40 text-center py-6 <%= 'hidden' if @transaction_name_overrides_pagy.count.positive? %>">
           No overrides yet. Edit a transaction name to add one.
         </p>
       </div>

--- a/app/views/transaction_name_overrides/_list.html.erb
+++ b/app/views/transaction_name_overrides/_list.html.erb
@@ -1,0 +1,11 @@
+<%# locals: (transaction_name_overrides:, transaction_name_overrides_pagy:) %>
+<div class="space-y-2 mt-2">
+  <% transaction_name_overrides.each do |override| %>
+    <%= render override, current_page: transaction_name_overrides_pagy.page %>
+  <% end %>
+  <p data-empty-state class="text-sm text-base-content/40 text-center py-6 <%= 'hidden' if transaction_name_overrides_pagy.count.positive? %>">
+    No overrides yet. Edit a transaction name to add one.
+  </p>
+</div>
+
+<%= render "components/pagination", pagy: transaction_name_overrides_pagy %>

--- a/app/views/transaction_name_overrides/_list.html.erb
+++ b/app/views/transaction_name_overrides/_list.html.erb
@@ -3,7 +3,7 @@
   <% transaction_name_overrides.each do |override| %>
     <%= render override, current_page: transaction_name_overrides_pagy.page %>
   <% end %>
-  <p data-empty-state class="text-sm text-base-content/40 text-center py-6 <%= 'hidden' if transaction_name_overrides_pagy.count.positive? %>">
+  <p data-empty-state class="text-sm text-base-content/40 text-center py-6 <%= 'hidden' if transaction_name_overrides.any? %>">
     No overrides yet. Edit a transaction name to add one.
   </p>
 </div>

--- a/app/views/transaction_name_overrides/_transaction_name_override.html.erb
+++ b/app/views/transaction_name_overrides/_transaction_name_override.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (transaction_name_override:, current_page: nil) %>
 <div id="<%= dom_id(transaction_name_override) %>" data-controller="dismissible" class="flex items-center justify-between px-4 py-3 gap-3 bg-base-200 rounded-xl">
   <div class="flex items-center gap-2 min-w-0 flex-1 text-sm">
     <span class="badge badge-sm <%= transaction_name_override.match_type == "exact" ? "badge-primary" : "badge-secondary" %> shrink-0">
@@ -8,7 +9,7 @@
     <span class="font-medium truncate">"<%= transaction_name_override.replacement_name %>"</span>
   </div>
 
-  <%= button_to transaction_name_override_path(transaction_name_override),
+  <%= button_to transaction_name_override_path(transaction_name_override, current_page ? { page: current_page } : {}),
       method: :delete,
       class: "btn btn-ghost btn-sm text-error shrink-0",
       data: { controller: "loading-button", loading_button_text_value: "" } do %>

--- a/app/views/transaction_name_overrides/_transaction_name_override.html.erb
+++ b/app/views/transaction_name_overrides/_transaction_name_override.html.erb
@@ -9,7 +9,8 @@
     <span class="font-medium truncate">"<%= transaction_name_override.replacement_name %>"</span>
   </div>
 
-  <%= button_to transaction_name_override_path(transaction_name_override, current_page ? { page: current_page } : {}),
+  <% delete_url_params = current_page ? { page: current_page, return_to: settings_path(page: current_page) } : {} %>
+  <%= button_to transaction_name_override_path(transaction_name_override, delete_url_params),
       method: :delete,
       class: "btn btn-ghost btn-sm text-error shrink-0",
       data: { controller: "loading-button", loading_button_text_value: "" } do %>

--- a/app/views/transaction_name_overrides/destroy.turbo_stream.erb
+++ b/app/views/transaction_name_overrides/destroy.turbo_stream.erb
@@ -13,5 +13,11 @@
     <% end %>
   <% end %>
 <% else %>
-  <%= turbo_stream.remove @override %>
+  <%= turbo_stream.replace "transaction_name_overrides" do %>
+    <%= turbo_frame_tag "transaction_name_overrides" do %>
+      <%= render "transaction_name_overrides/list",
+          transaction_name_overrides: @transaction_name_overrides,
+          transaction_name_overrides_pagy: @transaction_name_overrides_pagy %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,5 @@
+require 'pagy'
+require 'pagy/extras/overflow'
+
+Pagy::DEFAULT[:limit] = 5
+Pagy::DEFAULT[:overflow] = :last_page

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,5 +1,4 @@
 require 'pagy'
 require 'pagy/extras/overflow'
 
-Pagy::DEFAULT[:limit] = 5
 Pagy::DEFAULT[:overflow] = :last_page

--- a/test/controllers/settings_controller_test.rb
+++ b/test/controllers/settings_controller_test.rb
@@ -120,8 +120,7 @@ class SettingsControllerTest < ActionDispatch::IntegrationTest
 
   test 'show paginates transaction name overrides to 5 per page' do
     sign_in_as(@user)
-    # johndoe already has 2 fixture overrides; add 5 more so we have 7 total
-    5.times { |i| @user.transaction_name_overrides.create!(match_type: 'exact', match_text: "EXTRA#{i}", replacement_name: "Extra #{i}") }
+    seed_overrides(7)
 
     get settings_path
 
@@ -133,7 +132,7 @@ class SettingsControllerTest < ActionDispatch::IntegrationTest
 
   test 'show navigates to a later page of transaction name overrides' do
     sign_in_as(@user)
-    5.times { |i| @user.transaction_name_overrides.create!(match_type: 'exact', match_text: "EXTRA#{i}", replacement_name: "Extra #{i}") }
+    seed_overrides(7)
 
     get settings_path(page: 2)
 
@@ -145,7 +144,7 @@ class SettingsControllerTest < ActionDispatch::IntegrationTest
 
   test 'show clamps out-of-range page parameter to last available page' do
     sign_in_as(@user)
-    5.times { |i| @user.transaction_name_overrides.create!(match_type: 'exact', match_text: "EXTRA#{i}", replacement_name: "Extra #{i}") }
+    seed_overrides(7)
 
     get settings_path(page: 99)
 
@@ -155,6 +154,7 @@ class SettingsControllerTest < ActionDispatch::IntegrationTest
 
   test 'show does not render pagination when overrides fit in a single page' do
     sign_in_as(@user)
+    seed_overrides(3)
 
     get settings_path
 
@@ -187,5 +187,12 @@ class SettingsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select 'p', text: 'No linked account yet'
+  end
+
+  private
+
+  def seed_overrides(total)
+    @user.transaction_name_overrides.destroy_all
+    total.times { |i| @user.transaction_name_overrides.create!(match_type: 'exact', match_text: "SEED#{i}", replacement_name: "Seeded #{i}") }
   end
 end

--- a/test/controllers/settings_controller_test.rb
+++ b/test/controllers/settings_controller_test.rb
@@ -118,6 +118,50 @@ class SettingsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'Unable to initialize bank reconnection. Please try again later.', flash[:alert]
   end
 
+  test 'show paginates transaction name overrides to 5 per page' do
+    sign_in_as(@user)
+    # johndoe already has 2 fixture overrides; add 5 more so we have 7 total
+    5.times { |i| @user.transaction_name_overrides.create!(match_type: 'exact', match_text: "EXTRA#{i}", replacement_name: "Extra #{i}") }
+
+    get settings_path
+
+    assert_response :success
+    assert_select 'div[id^=transaction_name_override_]', count: 5
+    assert_select 'span', text: 'Page 1 of 2'
+    assert_select "a[href='#{settings_path(page: 2)}']"
+  end
+
+  test 'show navigates to a later page of transaction name overrides' do
+    sign_in_as(@user)
+    5.times { |i| @user.transaction_name_overrides.create!(match_type: 'exact', match_text: "EXTRA#{i}", replacement_name: "Extra #{i}") }
+
+    get settings_path(page: 2)
+
+    assert_response :success
+    assert_select 'div[id^=transaction_name_override_]', count: 2
+    assert_select 'span', text: 'Page 2 of 2'
+    assert_select "a[href='#{settings_path(page: 1)}']"
+  end
+
+  test 'show clamps out-of-range page parameter to last available page' do
+    sign_in_as(@user)
+    5.times { |i| @user.transaction_name_overrides.create!(match_type: 'exact', match_text: "EXTRA#{i}", replacement_name: "Extra #{i}") }
+
+    get settings_path(page: 99)
+
+    assert_response :success
+    assert_select 'span', text: 'Page 2 of 2'
+  end
+
+  test 'show does not render pagination when overrides fit in a single page' do
+    sign_in_as(@user)
+
+    get settings_path
+
+    assert_response :success
+    assert_select 'span', text: /Page \d+ of/, count: 0
+  end
+
   test 'show displays empty state when no banks linked' do
     # Mock Plaid link token creation
     stub_request(:post, 'https://sandbox.plaid.com/link/token/create')

--- a/test/controllers/transaction_name_overrides_controller_test.rb
+++ b/test/controllers/transaction_name_overrides_controller_test.rb
@@ -70,6 +70,21 @@ class TransactionNameOverridesControllerTest < ActionDispatch::IntegrationTest
     assert_match(/drawer_content/, response.body)
   end
 
+  test 'destroy from settings replaces the transaction_name_overrides frame with the current page' do
+    sign_in_as(@user)
+    @user.transaction_name_overrides.destroy_all
+    overrides = 7.times.map { |i| @user.transaction_name_overrides.create!(match_type: 'exact', match_text: "SEED#{i}", replacement_name: "Seeded #{i}") }
+    target = overrides.last
+
+    delete transaction_name_override_url(target, page: 2),
+           headers: { Accept: 'text/vnd.turbo-stream.html' }
+
+    assert_response :success
+    assert_match(/turbo-stream action="replace" target="transaction_name_overrides"/, response.body)
+    assert_match(/Page 2 of 2/, response.body)
+    assert_match(%r{href="/settings\?page=1"}, response.body)
+  end
+
   test 'destroy with missing record returns no_content for turbo_stream' do
     sign_in_as(@user)
 


### PR DESCRIPTION
## Summary

- Settings page paginates the transaction name overrides list (5 per page) using Pagy
- Pagy added as a dependency with a shared \`components/pagination\` partial styled to match the existing DaisyUI buttons
- Pagination links are scoped to a \`transaction_name_overrides\` Turbo Frame so paging swaps just the list, not the whole page
- Deletes from settings now respond with a Turbo Stream that replaces the entire frame with a freshly-paginated render — both the empty-state and the pagination footer reflect the post-delete dataset

## Test plan

- [ ] With six or more overrides: settings page shows page 1 with 5 items + a "Page 1 of N" footer and a Next button
- [ ] Clicking Next loads page 2 via the Turbo Frame (only the list area swaps, no full page reload)
- [ ] \`?page=999\` falls back to the last page via Pagy's overflow extra
- [ ] With five or fewer overrides: no pagination footer rendered
- [ ] Deleting an override on the current page replaces the list (no slide-out animation in the paginated flow); the empty state shows correctly when the last override on the only page is removed; pagination disappears when total drops at or below five

🤖 Generated with [Claude Code](https://claude.com/claude-code)