### PR TITLE
Fall back to counterparty logo when top-level fields are nil

### DIFF
--- a/app/services/transaction_sync_service.rb
+++ b/app/services/transaction_sync_service.rb
@@ -29,20 +29,7 @@ class TransactionSyncService
 
       transaction = Transaction.find_or_initialize_by(plaid_transaction_id: plaid_transaction.transaction_id)
       is_new = transaction.new_record?
-      transaction.assign_attributes(
-        bank_account_id: bank_account_id,
-        name: plaid_transaction.name,
-        amount: plaid_transaction.amount,
-        date: plaid_transaction.date,
-        authorized_date: plaid_transaction.authorized_date,
-        merchant_name: plaid_transaction.merchant_name,
-        pending: plaid_transaction.pending,
-        payment_channel: plaid_transaction.payment_channel,
-        personal_finance_category: plaid_transaction.personal_finance_category&.primary,
-        personal_finance_category_detailed: plaid_transaction.personal_finance_category&.detailed,
-        logo_url: plaid_transaction.logo_url,
-        merchant_entity_id: plaid_transaction.merchant_entity_id
-      )
+      transaction.assign_attributes(attributes_from_plaid(plaid_transaction, bank_account_id))
       transaction.save!
       new_transactions << transaction if is_new
     end
@@ -51,6 +38,29 @@ class TransactionSyncService
   end
 
   private_class_method :upsert_transactions
+
+  # Top-level `logo_url` / `merchant_entity_id` are nil for transactions whose primary counterparty
+  # is a financial institution (e.g. credit-card payments). Fall back to the first counterparty.
+  def self.attributes_from_plaid(plaid_transaction, bank_account_id)
+    counterparty = plaid_transaction.counterparties&.first
+
+    {
+      bank_account_id: bank_account_id,
+      name: plaid_transaction.name,
+      amount: plaid_transaction.amount,
+      date: plaid_transaction.date,
+      authorized_date: plaid_transaction.authorized_date,
+      merchant_name: plaid_transaction.merchant_name,
+      pending: plaid_transaction.pending,
+      payment_channel: plaid_transaction.payment_channel,
+      personal_finance_category: plaid_transaction.personal_finance_category&.primary,
+      personal_finance_category_detailed: plaid_transaction.personal_finance_category&.detailed,
+      logo_url: plaid_transaction.logo_url || counterparty&.logo_url,
+      merchant_entity_id: plaid_transaction.merchant_entity_id || counterparty&.entity_id
+    }
+  end
+
+  private_class_method :attributes_from_plaid
 
   def self.remove_transactions(removed)
     return if removed.empty?

--- a/test/services/transaction_sync_service_test.rb
+++ b/test/services/transaction_sync_service_test.rb
@@ -63,7 +63,7 @@ class TransactionSyncServiceTest < ActiveSupport::TestCase
     assert_equal @bank_account.id, txn.bank_account_id
   end
 
-  test 'sync falls back to first counterparty logo_url and entity_id when top-level fields are nil' do
+  test 'sync falls back to first counterparty logo_url and merchant_entity_id when top-level fields are nil' do
     counterparty = PlaidCounterparty.new(
       name: 'Apple Card',
       type: 'financial_institution',
@@ -90,7 +90,7 @@ class TransactionSyncServiceTest < ActiveSupport::TestCase
     assert_equal 'entity_apple_card', txn.merchant_entity_id
   end
 
-  test 'sync prefers top-level logo_url and entity_id over counterparty values' do
+  test 'sync prefers top-level logo_url and merchant_entity_id over counterparty values' do
     counterparty = PlaidCounterparty.new(
       name: 'Other',
       type: 'merchant',
@@ -238,10 +238,17 @@ class TransactionSyncServiceTest < ActiveSupport::TestCase
 
   private
 
-  def build_plaid_transaction(id, name, amount, account_id: nil, logo_url: 'https://example.com/logo.png', merchant_entity_id: 'merchant_123', counterparties: nil) # rubocop:disable Metrics/ParameterLists
+  def build_plaid_transaction(id, name, amount, **overrides)
+    attrs = {
+      account_id: @bank_account.plaid_account_id,
+      logo_url: 'https://example.com/logo.png',
+      merchant_entity_id: 'merchant_123',
+      counterparties: nil
+    }.merge(overrides)
+
     PlaidTransaction.new(
       transaction_id: id,
-      account_id: account_id || @bank_account.plaid_account_id,
+      account_id: attrs[:account_id],
       name: name,
       amount: amount,
       date: Date.current,
@@ -250,9 +257,9 @@ class TransactionSyncServiceTest < ActiveSupport::TestCase
       pending: false,
       payment_channel: 'in store',
       personal_finance_category: PlaidCategory.new(primary: 'FOOD_AND_DRINK', detailed: 'FOOD_AND_DRINK_COFFEE'),
-      logo_url: logo_url,
-      merchant_entity_id: merchant_entity_id,
-      counterparties: counterparties
+      logo_url: attrs[:logo_url],
+      merchant_entity_id: attrs[:merchant_entity_id],
+      counterparties: attrs[:counterparties]
     )
   end
 

--- a/test/services/transaction_sync_service_test.rb
+++ b/test/services/transaction_sync_service_test.rb
@@ -6,10 +6,11 @@ class TransactionSyncServiceTest < ActiveSupport::TestCase
   PlaidTransaction = Struct.new(
     :transaction_id, :account_id, :name, :amount, :date, :authorized_date,
     :merchant_name, :pending, :payment_channel, :personal_finance_category,
-    :logo_url, :merchant_entity_id
+    :logo_url, :merchant_entity_id, :counterparties
   )
 
   PlaidCategory = Struct.new(:primary, :detailed)
+  PlaidCounterparty = Struct.new(:name, :type, :logo_url, :entity_id)
   PlaidRemoved = Struct.new(:transaction_id)
 
   setup do
@@ -60,6 +61,60 @@ class TransactionSyncServiceTest < ActiveSupport::TestCase
     assert_equal 'Starbucks', txn.name
     assert_equal 5.50, txn.amount.to_f
     assert_equal @bank_account.id, txn.bank_account_id
+  end
+
+  test 'sync falls back to first counterparty logo_url and entity_id when top-level fields are nil' do
+    counterparty = PlaidCounterparty.new(
+      name: 'Apple Card',
+      type: 'financial_institution',
+      logo_url: 'https://plaid-counterparty-logos.plaid.com/apple_card_336.png',
+      entity_id: 'entity_apple_card'
+    )
+
+    txn_input = build_plaid_transaction(
+      'txn_fi_1',
+      'WITHDRAWAL ACH APPLECARD GSBANK',
+      122.50,
+      logo_url: nil,
+      merchant_entity_id: nil,
+      counterparties: [ counterparty ]
+    )
+
+    stub_sync_response(added: [ txn_input ])
+
+    TransactionSyncService.sync(bank: @bank)
+
+    txn = Transaction.find_by(plaid_transaction_id: 'txn_fi_1')
+
+    assert_equal 'https://plaid-counterparty-logos.plaid.com/apple_card_336.png', txn.logo_url
+    assert_equal 'entity_apple_card', txn.merchant_entity_id
+  end
+
+  test 'sync prefers top-level logo_url and entity_id over counterparty values' do
+    counterparty = PlaidCounterparty.new(
+      name: 'Other',
+      type: 'merchant',
+      logo_url: 'https://example.com/counterparty.png',
+      entity_id: 'counterparty_entity'
+    )
+
+    txn_input = build_plaid_transaction(
+      'txn_toplevel_1',
+      'Starbucks',
+      5.50,
+      logo_url: 'https://example.com/top.png',
+      merchant_entity_id: 'top_entity',
+      counterparties: [ counterparty ]
+    )
+
+    stub_sync_response(added: [ txn_input ])
+
+    TransactionSyncService.sync(bank: @bank)
+
+    txn = Transaction.find_by(plaid_transaction_id: 'txn_toplevel_1')
+
+    assert_equal 'https://example.com/top.png', txn.logo_url
+    assert_equal 'top_entity', txn.merchant_entity_id
   end
 
   test 'sync updates existing transactions from modified results' do
@@ -183,7 +238,7 @@ class TransactionSyncServiceTest < ActiveSupport::TestCase
 
   private
 
-  def build_plaid_transaction(id, name, amount, account_id: nil)
+  def build_plaid_transaction(id, name, amount, account_id: nil, logo_url: 'https://example.com/logo.png', merchant_entity_id: 'merchant_123', counterparties: nil) # rubocop:disable Metrics/ParameterLists
     PlaidTransaction.new(
       transaction_id: id,
       account_id: account_id || @bank_account.plaid_account_id,
@@ -195,8 +250,9 @@ class TransactionSyncServiceTest < ActiveSupport::TestCase
       pending: false,
       payment_channel: 'in store',
       personal_finance_category: PlaidCategory.new(primary: 'FOOD_AND_DRINK', detailed: 'FOOD_AND_DRINK_COFFEE'),
-      logo_url: 'https://example.com/logo.png',
-      merchant_entity_id: 'merchant_123'
+      logo_url: logo_url,
+      merchant_entity_id: merchant_entity_id,
+      counterparties: counterparties
     )
   end
 


### PR DESCRIPTION
## Summary
- Plaid's `transactions/sync` returns `logo_url` and `merchant_entity_id` as `nil` at the top level for transactions whose primary counterparty is a financial institution (Apple Card, Discover, Chase Card, etc.) — but the enrichment data is still present on the per-transaction `counterparties[]` array.
- `TransactionSyncService#upsert_transactions` now falls back to `counterparties.first` when the top-level fields are nil, so these transactions get their logos on the next sync.
- Extracted the Plaid → attribute mapping into a private `attributes_from_plaid` helper to keep `upsert_transactions` readable.

Verified against staging: enrich and sync both return the Apple Card logo via the counterparty entry; sync was just dropping it.

No backfill — existing rows without logos will stay blank until Plaid marks them as `modified`. New syncs benefit immediately.

## Test plan
- [x] `bin/rails test test/services/transaction_sync_service_test.rb` — 12 runs, 0 failures
- [x] `bin/rubocop app/services/transaction_sync_service.rb test/services/transaction_sync_service_test.rb` — no offenses
- [x] New test: fallback fires when top-level fields are nil
- [x] New test: top-level values win when both are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)