### PR TITLE
Render pending state as a subtle badge on transaction detail

### DIFF
--- a/app/views/transactions/_transaction_detail.html.erb
+++ b/app/views/transactions/_transaction_detail.html.erb
@@ -29,6 +29,9 @@
       <div class="min-w-0 flex-1" data-controller="toggle" data-toggle-delay-frame-value="drawer_content">
         <div class="flex items-center gap-1.5">
           <h3 class="text-xl font-bold leading-tight truncate"><%= main_name %></h3>
+          <% if transaction.pending? %>
+            <span class="badge badge-ghost badge-sm shrink-0">Pending</span>
+          <% end %>
           <button data-action="toggle#toggle" class="btn btn-ghost btn-xs btn-circle shrink-0 text-primary hover:text-primary" title="Edit name">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
@@ -98,11 +101,8 @@
     </div>
 
     <%# Amount %>
-    <div class="flex items-center text-3xl font-bold <%= transaction.amount.negative? ? 'text-success' : 'text-error' %>">
-      <span><%= transaction.amount.negative? ? "+" : "" %><%= number_to_currency(transaction.amount.abs) %></span>
-      <% if transaction.pending? %>
-        <span class="badge badge-ghost badge-sm ml-2">Pending</span>
-      <% end %>
+    <div class="text-3xl font-bold <%= transaction.amount.negative? ? 'text-success' : 'text-error' %>">
+      <%= transaction.amount.negative? ? "+" : "" %><%= number_to_currency(transaction.amount.abs) %>
     </div>
 
     <%# Details %>

--- a/app/views/transactions/_transaction_detail.html.erb
+++ b/app/views/transactions/_transaction_detail.html.erb
@@ -28,7 +28,7 @@
 
       <div class="min-w-0 flex-1" data-controller="toggle" data-toggle-delay-frame-value="drawer_content">
         <div class="flex items-center gap-1.5">
-          <h3 class="text-xl font-bold leading-tight truncate"><%= main_name %></h3>
+          <h3 class="text-xl font-bold leading-tight truncate min-w-0"><%= main_name %></h3>
           <% if transaction.pending? %>
             <span class="badge badge-ghost badge-sm shrink-0">Pending</span>
           <% end %>

--- a/app/views/transactions/_transaction_detail.html.erb
+++ b/app/views/transactions/_transaction_detail.html.erb
@@ -98,10 +98,10 @@
     </div>
 
     <%# Amount %>
-    <div class="text-3xl font-bold <%= transaction.amount.negative? ? 'text-success' : 'text-error' %>">
-      <%= transaction.amount.negative? ? "+" : "" %><%= number_to_currency(transaction.amount.abs) %>
+    <div class="flex items-center text-3xl font-bold <%= transaction.amount.negative? ? 'text-success' : 'text-error' %>">
+      <span><%= transaction.amount.negative? ? "+" : "" %><%= number_to_currency(transaction.amount.abs) %></span>
       <% if transaction.pending? %>
-        <span class="badge badge-ghost badge-sm ml-2 align-middle">Pending</span>
+        <span class="badge badge-ghost badge-sm ml-2">Pending</span>
       <% end %>
     </div>
 

--- a/app/views/transactions/_transaction_detail.html.erb
+++ b/app/views/transactions/_transaction_detail.html.erb
@@ -101,7 +101,7 @@
     <div class="text-3xl font-bold <%= transaction.amount.negative? ? 'text-success' : 'text-error' %>">
       <%= transaction.amount.negative? ? "+" : "" %><%= number_to_currency(transaction.amount.abs) %>
       <% if transaction.pending? %>
-        <span class="text-base font-normal text-base-content/50 ml-1">Pending</span>
+        <span class="badge badge-ghost badge-sm ml-2 align-middle">Pending</span>
       <% end %>
     </div>
 


### PR DESCRIPTION
## Summary
- Add a small DaisyUI `badge badge-ghost badge-sm` next to the transaction name on the detail drawer when the transaction is pending.
- Replaces the plain "Pending" text that used to sit next to the amount — pending reads as a status on the transaction itself, not the amount.
- List view is unchanged — it keeps the existing clock-icon + dimmed-row treatment, which works fine in a dense list.

## Test plan
- [ ] `bin/dev`, open the drawer for a pending transaction, confirm the badge sits inline with the name and is vertically centered.
- [ ] Confirm non-pending transactions render unchanged (no badge).
- [ ] Long merchant names still truncate cleanly without squeezing the badge out (`shrink-0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)