### PR TITLE
Paginate transactions index at 25 per page

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -1,7 +1,10 @@
 class TransactionsController < ApplicationController
   def index
     @transaction_name_overrides = Current.user.transaction_name_overrides.to_a
-    @transactions = Current.user.transactions.order(Arel.sql('date DESC NULLS LAST, created_at DESC')).load
+    @transactions_pagy, @transactions = pagy(
+      Current.user.transactions.order(Arel.sql('date DESC NULLS LAST, created_at DESC')),
+      limit: 25
+    )
     @has_bank = Current.user.banks.exists? if @transactions.empty?
   end
 

--- a/app/views/transactions/index.html.erb
+++ b/app/views/transactions/index.html.erb
@@ -29,6 +29,10 @@
         </div>
       <% end %>
     </div>
+
+    <div class="w-full max-w-240 px-4">
+      <%= render "components/pagination", pagy: @transactions_pagy %>
+    </div>
   <% elsif !@has_bank %>
     <div class="card card-lg bg-base-100 mt-4 w-full max-w-240 shadow-glow">
       <div class="card-body">

--- a/app/views/transactions/index.html.erb
+++ b/app/views/transactions/index.html.erb
@@ -30,9 +30,11 @@
       <% end %>
     </div>
 
-    <div class="w-full max-w-240 px-4">
-      <%= render "components/pagination", pagy: @transactions_pagy %>
-    </div>
+    <% if @transactions_pagy.pages > 1 %>
+      <div class="w-full max-w-240 px-4">
+        <%= render "components/pagination", pagy: @transactions_pagy %>
+      </div>
+    <% end %>
   <% elsif !@has_bank %>
     <div class="card card-lg bg-base-100 mt-4 w-full max-w-240 shadow-glow">
       <div class="card-body">

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -47,6 +47,38 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     assert_select 'p', text: 'ExactRenamed'
   end
 
+  test 'index paginates transactions at 25 per page' do
+    account = bank_accounts(:chase_checking)
+    30.times do |i|
+      Transaction.create!(name: "Txn #{i}", amount: 1.00 + i, date: Date.current - i.days, bank_account: account)
+    end
+    sign_in_as(users(:johndoe))
+
+    get transactions_url
+
+    assert_response :success
+    assert_select 'p', text: 'Txn 0'
+    assert_select 'p', text: 'Txn 24'
+    assert_select 'p', text: 'Txn 25', count: 0
+    assert_select 'a', text: /Next/
+  end
+
+  test 'index second page shows the next batch of transactions' do
+    account = bank_accounts(:chase_checking)
+    30.times do |i|
+      Transaction.create!(name: "Txn #{i}", amount: 1.00 + i, date: Date.current - i.days, bank_account: account)
+    end
+    sign_in_as(users(:johndoe))
+
+    get transactions_url(page: 2)
+
+    assert_response :success
+    assert_select 'p', text: 'Txn 25'
+    assert_select 'p', text: 'Txn 29'
+    assert_select 'p', text: 'Txn 0', count: 0
+    assert_select 'a', text: /Prev/
+  end
+
   test 'show requires authentication' do
     transaction = Transaction.create!(name: 'TESTEXACT', amount: 5.50, bank_account: bank_accounts(:chase_checking))
 


### PR DESCRIPTION
## Summary
- Route `TransactionsController#index` through Pagy with `limit: 25` instead of loading the user's full transaction history.
- Render the shared `components/pagination` partial below the date-grouped list when there's more than one page.
- Mirrors the override-pagination pattern already in use on the settings page (`SettingsController#show`), so styling and navigation are consistent.

## Test plan
- [x] `bin/rails test test/controllers/transactions_controller_test.rb` — 13 runs, 0 failures
- [x] New test: page 1 shows the first 25 transactions and a "Next" link
- [x] New test: page 2 shows the remaining transactions and a "Prev" link
- [ ] `bin/dev`, scroll to the bottom of the transactions page with >25 transactions, confirm pagination controls render and navigate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)