### PR TITLE
Show available balance on the transactions page

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -5,7 +5,8 @@ class TransactionsController < ApplicationController
       Current.user.transactions.order(Arel.sql('date DESC NULLS LAST, created_at DESC')),
       limit: 25
     )
-    @has_bank = Current.user.banks.exists? if @transactions.empty?
+    @has_bank = Current.user.banks.exists?
+    @available_balance = Current.user.bank_accounts.sum(:available_balance) if @has_bank
   end
 
   def show

--- a/app/views/transactions/index.html.erb
+++ b/app/views/transactions/index.html.erb
@@ -3,7 +3,7 @@
 <div class="flex flex-col items-center pb-10">
   <div class="w-full max-w-240 mt-10 px-4 flex items-baseline justify-between gap-3">
     <h2 class="text-2xl font-bold">Transactions</h2>
-    <% if @available_balance %>
+    <% if @has_bank %>
       <div class="text-sm text-right">
         <span class="text-base-content/60">Available Balance:</span>
         <span class="font-semibold tabular-nums ml-1"><%= number_to_currency(@available_balance) %></span>

--- a/app/views/transactions/index.html.erb
+++ b/app/views/transactions/index.html.erb
@@ -1,14 +1,15 @@
 <% content_for :title, "Transactions" %>
 
 <div class="flex flex-col items-center pb-10">
-  <h2 class="text-2xl font-bold mt-10 w-full max-w-240 px-4">Transactions</h2>
-
-  <% if @available_balance %>
-    <div class="w-full max-w-240 px-4 mt-1 text-right text-sm">
-      <span class="text-base-content/60">Available Balance:</span>
-      <span class="font-semibold tabular-nums ml-1"><%= number_to_currency(@available_balance) %></span>
-    </div>
-  <% end %>
+  <div class="w-full max-w-240 mt-10 px-4 flex items-baseline justify-between gap-3">
+    <h2 class="text-2xl font-bold">Transactions</h2>
+    <% if @available_balance %>
+      <div class="text-sm text-right">
+        <span class="text-base-content/60">Available Balance:</span>
+        <span class="font-semibold tabular-nums ml-1"><%= number_to_currency(@available_balance) %></span>
+      </div>
+    <% end %>
+  </div>
 
   <% if @transactions.any? %>
     <div class="w-full max-w-240 mt-4 space-y-6">

--- a/app/views/transactions/index.html.erb
+++ b/app/views/transactions/index.html.erb
@@ -4,9 +4,9 @@
   <h2 class="text-2xl font-bold mt-10 w-full max-w-240 px-4">Transactions</h2>
 
   <% if @available_balance %>
-    <div class="w-full max-w-240 px-4 mt-3">
-      <p class="text-sm text-base-content/60">Available Balance</p>
-      <p class="text-3xl font-bold tabular-nums"><%= number_to_currency(@available_balance) %></p>
+    <div class="w-full max-w-240 px-4 mt-1 text-right text-sm">
+      <span class="text-base-content/60">Available Balance:</span>
+      <span class="font-semibold tabular-nums ml-1"><%= number_to_currency(@available_balance) %></span>
     </div>
   <% end %>
 

--- a/app/views/transactions/index.html.erb
+++ b/app/views/transactions/index.html.erb
@@ -3,6 +3,13 @@
 <div class="flex flex-col items-center pb-10">
   <h2 class="text-2xl font-bold mt-10 w-full max-w-240 px-4">Transactions</h2>
 
+  <% if @available_balance %>
+    <div class="w-full max-w-240 px-4 mt-3">
+      <p class="text-sm text-base-content/60">Available Balance</p>
+      <p class="text-3xl font-bold tabular-nums"><%= number_to_currency(@available_balance) %></p>
+    </div>
+  <% end %>
+
   <% if @transactions.any? %>
     <div class="w-full max-w-240 mt-4 space-y-6">
       <% @transactions.group_by(&:date).each do |date, transactions| %>

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -79,6 +79,25 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     assert_select 'a', text: /Prev/
   end
 
+  test 'index shows aggregated available balance when a bank is linked' do
+    sign_in_as(users(:johndoe))
+
+    get transactions_url
+
+    assert_response :success
+    assert_select 'p', text: 'Available Balance'
+    assert_select 'p', text: '$6,000.00'
+  end
+
+  test 'index does not render an available balance when no bank is linked' do
+    sign_in_as(users(:admin))
+
+    get transactions_url
+
+    assert_response :success
+    assert_select 'p', text: 'Available Balance', count: 0
+  end
+
   test 'show requires authentication' do
     transaction = Transaction.create!(name: 'TESTEXACT', amount: 5.50, bank_account: bank_accounts(:chase_checking))
 

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -85,8 +85,8 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     get transactions_url
 
     assert_response :success
-    assert_select 'p', text: 'Available Balance'
-    assert_select 'p', text: '$6,000.00'
+    assert_select 'span', text: 'Available Balance:'
+    assert_select 'span', text: '$6,000.00'
   end
 
   test 'index does not render an available balance when no bank is linked' do
@@ -95,7 +95,7 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     get transactions_url
 
     assert_response :success
-    assert_select 'p', text: 'Available Balance', count: 0
+    assert_select 'span', text: 'Available Balance:', count: 0
   end
 
   test 'show requires authentication' do


### PR DESCRIPTION
## Summary
- Sum `available_balance` across the user's `bank_accounts` and render it as a labeled value (\"Available Balance\" / `$X,XXX.XX`) just under the page heading on the transactions index.
- Picks `available_balance` over `current_balance` because the app's framing is "safe to spend" — available excludes pending charges, which matches the budget-from-paycheck mental model better than the raw ledger total.
- Sums across `bank_accounts` even though `Bank` enforces one-per-user (`app/models/bank.rb:21`), because a single Item from Plaid can still return multiple checking accounts.
- Only renders when the user has a linked bank; the existing "No bank account linked" empty state continues to handle the unlinked case unchanged.

## Test plan
- [x] `bin/rails test test/controllers/transactions_controller_test.rb` — 15 runs, 0 failures
- [x] New test: johndoe (Chase bank + chase_checking + chase_savings fixtures) sees `$6,000.00` available balance
- [x] New test: admin (no bank) does not see an available balance row
- [ ] `bin/dev`, confirm the value renders cleanly under the page heading on a real account

🤖 Generated with [Claude Code](https://claude.com/claude-code)