### PR TITLE
Refresh bank_account balances on every transactions/sync

### DIFF
--- a/app/services/plaid_service.rb
+++ b/app/services/plaid_service.rb
@@ -97,7 +97,7 @@ class PlaidService
       added.concat(response.added)
       modified.concat(response.modified)
       removed.concat(response.removed)
-      accounts = response.accounts
+      accounts = response.accounts || []
       cursor = response.next_cursor
 
       break unless response.has_more

--- a/app/services/plaid_service.rb
+++ b/app/services/plaid_service.rb
@@ -85,6 +85,7 @@ class PlaidService
     added = []
     modified = []
     removed = []
+    accounts = []
 
     loop do
       request = Plaid::TransactionsSyncRequest.new(
@@ -96,12 +97,13 @@ class PlaidService
       added.concat(response.added)
       modified.concat(response.modified)
       removed.concat(response.removed)
+      accounts = response.accounts
       cursor = response.next_cursor
 
       break unless response.has_more
     end
 
-    { added: added, modified: modified, removed: removed, cursor: cursor }
+    { added: added, modified: modified, removed: removed, accounts: accounts, cursor: cursor }
   end
 
   def self.verify_webhook(body, plaid_verification_header)

--- a/app/services/transaction_sync_service.rb
+++ b/app/services/transaction_sync_service.rb
@@ -76,9 +76,10 @@ class TransactionSyncService
   # account included in the Plaid sync response.
   def self.refresh_bank_accounts(bank, plaid_accounts)
     balances_by_plaid_id = (plaid_accounts || []).index_by(&:account_id)
+    synced_at = Time.current
 
     bank.bank_accounts.find_each do |account|
-      attrs = { last_synced_at: Time.current }
+      attrs = { last_synced_at: synced_at }
 
       if (plaid_account = balances_by_plaid_id[account.plaid_account_id])
         attrs[:available_balance] = plaid_account.balances.available

--- a/app/services/transaction_sync_service.rb
+++ b/app/services/transaction_sync_service.rb
@@ -8,7 +8,7 @@ class TransactionSyncService
     remove_transactions(result[:removed])
 
     bank.update!(transaction_cursor: result[:cursor])
-    bank.bank_accounts.find_each { |account| account.update!(last_synced_at: Time.current) }
+    refresh_bank_accounts(bank, result[:accounts])
 
     SendPushNotificationJob.perform_later(bank.user_id, new_transactions.map(&:id)) if new_transactions.any?
   rescue Plaid::ApiError => error
@@ -71,4 +71,23 @@ class TransactionSyncService
   end
 
   private_class_method :remove_transactions
+
+  # Bump `last_synced_at` on every bank_account, and refresh balances for any
+  # account included in the Plaid sync response.
+  def self.refresh_bank_accounts(bank, plaid_accounts)
+    balances_by_plaid_id = (plaid_accounts || []).index_by(&:account_id)
+
+    bank.bank_accounts.find_each do |account|
+      attrs = { last_synced_at: Time.current }
+
+      if (plaid_account = balances_by_plaid_id[account.plaid_account_id])
+        attrs[:available_balance] = plaid_account.balances.available
+        attrs[:current_balance] = plaid_account.balances.current
+      end
+
+      account.update!(attrs)
+    end
+  end
+
+  private_class_method :refresh_bank_accounts
 end

--- a/test/services/plaid_service_test.rb
+++ b/test/services/plaid_service_test.rb
@@ -238,7 +238,7 @@ class PlaidServiceTest < ActiveSupport::TestCase
     assert_equal true, result
   end
 
-  test 'sync_transactions returns added, modified, removed and cursor' do
+  test 'sync_transactions returns added, modified, removed, accounts, and cursor' do
     stub_request(:post, 'https://sandbox.plaid.com/transactions/sync')
       .to_return(
         status: 200,
@@ -251,6 +251,8 @@ class PlaidServiceTest < ActiveSupport::TestCase
                      logo_url: nil, merchant_entity_id: nil, iso_currency_code: 'USD' } ],
           modified: [],
           removed: [],
+          accounts: [ { account_id: 'acc_1', name: 'Checking', type: 'depository', subtype: 'checking',
+                        balances: { available: 250.25, current: 275.50, iso_currency_code: 'USD' } } ],
           next_cursor: 'cursor_abc',
           has_more: false,
           request_id: 'req-123'
@@ -263,6 +265,10 @@ class PlaidServiceTest < ActiveSupport::TestCase
     assert_equal 'txn_1', result[:added].first.transaction_id
     assert_empty result[:modified]
     assert_empty result[:removed]
+    assert_equal 1, result[:accounts].length
+    assert_equal 'acc_1', result[:accounts].first.account_id
+    assert_equal 250.25, result[:accounts].first.balances.available
+    assert_equal 275.50, result[:accounts].first.balances.current
     assert_equal 'cursor_abc', result[:cursor]
   end
 

--- a/test/services/transaction_sync_service_test.rb
+++ b/test/services/transaction_sync_service_test.rb
@@ -12,6 +12,8 @@ class TransactionSyncServiceTest < ActiveSupport::TestCase
   PlaidCategory = Struct.new(:primary, :detailed)
   PlaidCounterparty = Struct.new(:name, :type, :logo_url, :entity_id)
   PlaidRemoved = Struct.new(:transaction_id)
+  PlaidBalances = Struct.new(:available, :current)
+  PlaidAccount = Struct.new(:account_id, :balances)
 
   setup do
     @user = User.create!(
@@ -222,6 +224,49 @@ class TransactionSyncServiceTest < ActiveSupport::TestCase
     end
   end
 
+  test 'sync refreshes balances on bank_accounts present in the response' do
+    @bank_account.update!(available_balance: 100.00, current_balance: 100.00)
+
+    plaid_account = build_plaid_account(@bank_account.plaid_account_id, available: 250.25, current: 275.50)
+
+    stub_sync_response(accounts: [ plaid_account ])
+
+    TransactionSyncService.sync(bank: @bank)
+
+    @bank_account.reload
+
+    assert_equal 250.25, @bank_account.available_balance.to_f
+    assert_equal 275.50, @bank_account.current_balance.to_f
+  end
+
+  test 'sync leaves balances untouched for accounts not in the response' do
+    @bank_account.update!(available_balance: 100.00, current_balance: 100.00)
+
+    stub_sync_response(accounts: [])
+
+    TransactionSyncService.sync(bank: @bank)
+
+    @bank_account.reload
+
+    assert_equal 100.00, @bank_account.available_balance.to_f
+    assert_equal 100.00, @bank_account.current_balance.to_f
+  end
+
+  test 'sync ignores plaid accounts that do not correspond to a bank_account' do
+    @bank_account.update!(available_balance: 100.00, current_balance: 100.00)
+
+    plaid_account = build_plaid_account('unknown_plaid_account_id', available: 999.00, current: 999.00)
+
+    stub_sync_response(accounts: [ plaid_account ])
+
+    TransactionSyncService.sync(bank: @bank)
+
+    @bank_account.reload
+
+    assert_equal 100.00, @bank_account.available_balance.to_f
+    assert_equal 100.00, @bank_account.current_balance.to_f
+  end
+
   test 'sync passes existing cursor to PlaidService' do
     @bank.update!(transaction_cursor: 'existing_cursor')
 
@@ -263,8 +308,12 @@ class TransactionSyncServiceTest < ActiveSupport::TestCase
     )
   end
 
-  def stub_sync_response(added: [], modified: [], removed: [], cursor: 'cursor_abc')
-    result = { added: added, modified: modified, removed: removed, cursor: cursor }
+  def stub_sync_response(added: [], modified: [], removed: [], accounts: [], cursor: 'cursor_abc')
+    result = { added: added, modified: modified, removed: removed, accounts: accounts, cursor: cursor }
     PlaidService.define_singleton_method(:sync_transactions) { |*, **| result }
+  end
+
+  def build_plaid_account(plaid_account_id, available:, current:)
+    PlaidAccount.new(account_id: plaid_account_id, balances: PlaidBalances.new(available: available, current: current))
   end
 end


### PR DESCRIPTION
## Summary
- Plaid's `/transactions/sync` response includes an `accounts` array with `balances.available` and `balances.current` for every account on the Item, but `PlaidService.sync_transactions` was throwing it away — so `available_balance` / `current_balance` on each `bank_account` were frozen at link time.
- `PlaidService.sync_transactions` now includes `accounts` in its return hash.
- `TransactionSyncService.sync` consolidates the `last_synced_at` bump and a balance refresh into a single pass over `bank.bank_accounts`. Accounts that appear in the response get their balances updated; accounts that don't appear are left alone (balances unchanged, but `last_synced_at` still bumped — same as before).
- Fixes the "stale account balance" bug visible on the transactions index page (added via #181).

## Test plan
- [x] `bin/rails test test/services` — 48 runs, 0 failures
- [x] PlaidService test: `sync_transactions` returns the parsed `accounts` array with balances
- [x] TransactionSyncService tests:
  - balances on matching accounts get refreshed
  - balances left untouched when the response omits accounts
  - plaid accounts that don't correspond to any local `bank_account` are silently ignored
- [ ] `bin/dev`, trigger a webhook (or wait for a real sync), verify the transactions page Available Balance reflects the new value

🤖 Generated with [Claude Code](https://claude.com/claude-code)