### PR TITLE
Fix drawer overlay, loading state, and pagination centering

### DIFF
--- a/app/controllers/transaction_name_overrides_controller.rb
+++ b/app/controllers/transaction_name_overrides_controller.rb
@@ -59,7 +59,7 @@ class TransactionNameOverridesController < ApplicationController
   def load_transaction_for_drawer
     return if params[:transaction_id].blank?
 
-    @transaction = Current.user.transactions.includes(:bank_account).find(params.expect(:transaction_id))
+    @transaction = Current.user.transactions.find(params.expect(:transaction_id))
     @transaction_name_override = @transaction.applied_override(@transaction_name_overrides)
   end
 

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -10,7 +10,7 @@ class TransactionsController < ApplicationController
   end
 
   def show
-    @transaction = Current.user.transactions.includes(:bank_account).find(params.expect(:id))
+    @transaction = Current.user.transactions.find(params.expect(:id))
     @transaction_name_overrides = Current.user.transaction_name_overrides.to_a
     @transaction_name_override = @transaction.applied_override(@transaction_name_overrides)
   end

--- a/app/javascript/controllers/drawer_controller.js
+++ b/app/javascript/controllers/drawer_controller.js
@@ -1,8 +1,9 @@
 import { Controller } from "@hotwired/stimulus"
 
 const LOADING_TEMPLATE = `
-  <div class="absolute inset-0 flex items-center justify-center">
-    <span class="loading loading-spinner loading-lg text-base-content/40"></span>
+  <div role="status" aria-live="polite" class="absolute inset-0 flex items-center justify-center">
+    <span class="loading loading-spinner loading-lg text-base-content/40" aria-hidden="true"></span>
+    <span class="sr-only">Loading transaction</span>
   </div>
 `
 

--- a/app/javascript/controllers/drawer_controller.js
+++ b/app/javascript/controllers/drawer_controller.js
@@ -1,5 +1,11 @@
 import { Controller } from "@hotwired/stimulus"
 
+const LOADING_TEMPLATE = `
+  <div class="flex items-center justify-center h-full p-12">
+    <span class="loading loading-spinner loading-lg text-base-content/40"></span>
+  </div>
+`
+
 export default class extends Controller {
   static targets = ["panel", "overlay"]
 
@@ -8,6 +14,7 @@ export default class extends Controller {
   }
 
   open() {
+    this.resetContent()
     this.overlayTarget.classList.remove("opacity-0", "pointer-events-none")
     this.panelTarget.classList.remove("translate-x-full")
     document.addEventListener("keydown", this.handleEscape)
@@ -22,6 +29,13 @@ export default class extends Controller {
 
   handleEscape(event) {
     if (event.key === "Escape") this.close()
+  }
+
+  // Clear stale content and show a loading state before Turbo fetches the new frame.
+  // Runs synchronously in the click handler, so it lands before Turbo's navigation.
+  resetContent() {
+    const frame = document.getElementById("drawer_content")
+    if (frame) frame.innerHTML = LOADING_TEMPLATE
   }
 
   disconnect() {

--- a/app/javascript/controllers/drawer_controller.js
+++ b/app/javascript/controllers/drawer_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 const LOADING_TEMPLATE = `
-  <div class="flex items-center justify-center h-full p-12">
+  <div class="absolute inset-0 flex items-center justify-center">
     <span class="loading loading-spinner loading-lg text-base-content/40"></span>
   </div>
 `

--- a/app/views/components/_pagination.html.erb
+++ b/app/views/components/_pagination.html.erb
@@ -1,29 +1,29 @@
 <%# locals: (pagy:) %>
 
 <% if pagy.pages > 1 %>
-  <div class="flex items-center justify-between mt-4 pt-4 border-t border-base-300">
-    <% if pagy.previous %>
-      <%= link_to pagy.page_url(pagy.previous), class: "btn btn-ghost btn-sm" do %>
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
-        </svg>
-        Prev
+  <div class="grid grid-cols-3 items-center mt-4 pt-4 border-t border-base-300">
+    <div class="justify-self-start">
+      <% if pagy.previous %>
+        <%= link_to pagy.page_url(pagy.previous), class: "btn btn-ghost btn-sm" do %>
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+          </svg>
+          Prev
+        <% end %>
       <% end %>
-    <% else %>
-      <span></span>
-    <% end %>
+    </div>
 
-    <span class="text-sm text-base-content/60">Page <%= pagy.page %> of <%= pagy.pages %></span>
+    <span class="text-sm text-base-content/60 justify-self-center">Page <%= pagy.page %> of <%= pagy.pages %></span>
 
-    <% if pagy.next %>
-      <%= link_to pagy.page_url(pagy.next), class: "btn btn-ghost btn-sm" do %>
-        Next
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-        </svg>
+    <div class="justify-self-end">
+      <% if pagy.next %>
+        <%= link_to pagy.page_url(pagy.next), class: "btn btn-ghost btn-sm" do %>
+          Next
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+          </svg>
+        <% end %>
       <% end %>
-    <% else %>
-      <span></span>
-    <% end %>
+    </div>
   </div>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -64,14 +64,17 @@
     <%= render "components/bottom_navigation" unless authentication_page? %>
 
     <%# Drawer overlay (slide-over for transaction detail and similar) %>
+    <%# Hidden when the drawer is full-width (viewport ≤ max-w-md), since there's nothing %>
+    <%# behind the drawer to tint and the iOS PWA safe-area inset would leak through. %>
     <div data-drawer-target="overlay"
-         class="fixed inset-0 bg-black/50 z-40 opacity-0 pointer-events-none transition-opacity duration-300 cursor-pointer"
+         class="fixed inset-0 bg-black/50 z-40 opacity-0 pointer-events-none transition-opacity duration-300 cursor-pointer max-[28rem]:hidden"
          data-action="click->drawer#close">
     </div>
 
-    <%# Drawer panel %>
+    <%# Drawer panel — bg matches <html> so iOS PWA doesn't tint the safe area %>
+    <%# with a different shade when the drawer fills the viewport. %>
     <div data-drawer-target="panel"
-         class="fixed inset-y-0 right-0 z-50 w-full max-w-md bg-base-100 shadow-2xl transform translate-x-full transition-transform duration-300 flex flex-col">
+         class="fixed inset-y-0 right-0 z-50 w-full max-w-md bg-base-100 dark:bg-base-300 shadow-2xl transform translate-x-full transition-transform duration-300 flex flex-col">
       <% unless content_for?(:drawer_frame_provided) %>
         <%= turbo_frame_tag "drawer_content" %>
       <% end %>

--- a/app/views/transactions/_transaction_detail.html.erb
+++ b/app/views/transactions/_transaction_detail.html.erb
@@ -128,19 +128,6 @@
         </div>
       <% end %>
 
-      <% if transaction.payment_channel.present? %>
-        <div class="flex justify-between gap-4">
-          <span class="text-base-content/50">Channel</span>
-          <span class="font-medium text-right"><%= transaction.payment_channel.gsub("_", " ").titleize %></span>
-        </div>
-      <% end %>
-
-      <% if transaction.bank_account %>
-        <div class="flex justify-between gap-4">
-          <span class="text-base-content/50">Account</span>
-          <span class="font-medium text-right"><%= transaction.bank_account.name %></span>
-        </div>
-      <% end %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Hide the drawer overlay on viewports where the panel is full-width (`max-[28rem]:hidden`). On iOS PWA the overlay's gray tint was leaking into the safe-area regions and lingering after close.
- In dark mode the drawer panel now uses `bg-base-300` to match `<html>`, so iOS doesn't tint the status-bar area with a different shade when the panel fills the viewport.
- `drawer#open` wipes the `drawer_content` frame and drops in a daisyUI spinner before Turbo fetches, so slow loads show a loader and you no longer see the previous transaction's details flash. Spinner has `role=status` + sr-only label for screen readers.
- Pagination row switched from `flex justify-between` to a 3-column grid so the "Page X of Y" label stays centered on the first page (where the Prev button is missing).
- Drop the Channel and Account rows from the transaction detail drawer — they weren't carrying their weight. Also remove the now-unused `bank_account` eager loads.

## Test plan
- [ ] Open a transaction on iOS PWA in dark mode, confirm no overlay tint on the status bar while drawer is open and no lingering shade after close
- [ ] Same check in light mode
- [ ] Throttle network, open a transaction, confirm spinner shows in the drawer (centered)
- [ ] Click one transaction, then another — confirm no flash of the previous transaction's details
- [ ] On a paginated list, confirm "Page X of Y" stays centered on page 1 and on later pages
- [ ] On a wider viewport (≥ 28rem), confirm the overlay still shows behind the drawer and click-outside-to-close still works
- [ ] Confirm transaction detail still shows date, merchant, category, name (Channel and Account intentionally removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)