### PR TITLE
Add expenses

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -78,21 +78,53 @@
   box-shadow: 0 0 15px rgba(0, 0, 0, 0.1);
 }
 
-/* Match the drawer overlay's tint and 300ms fade so confirm-modals
-   feel consistent with the slide-over drawer (bg-black/50). daisyUI's
-   default opacity transition is 100ms which reads as a flash. */
-.modal-backdrop {
-  background-color: rgba(0, 0, 0, 0.5);
+/* daisyUI swaps :root's background to a tinted gradient when a modal opens
+   (--page-scroll-bg-on). With our layout's bg-base-300 dark page, that
+   "tinted" variant is actually LIGHTER than the page itself — so the user
+   sees the page brighten before darkening. Disable that swap. */
+:root, [data-theme] {
+  --page-scroll-bg-on: var(--root-bg);
 }
 
+/* Backdrop behaves exactly like the drawer overlay: opacity 0→1 over 300ms
+   with Tailwind's default ease, constant bg-black/50. The modal-box is held
+   invisible until the backdrop finishes fading in, then it appears — same
+   spirit as the drawer where the panel arrives after / alongside its overlay
+   rather than ghosting through it. */
 .modal {
+  background-color: rgba(0, 0, 0, 0.5);
   opacity: 0;
-  transition: visibility 0.3s allow-discrete, background-color 0.3s ease-out, opacity 0.3s ease-out;
+  pointer-events: none;
+  transition: opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1), visibility 0.3s allow-discrete;
 }
 
 .modal-toggle:checked + .modal {
+  background-color: rgba(0, 0, 0, 0.5);
   opacity: 1;
-  transition: visibility 0s allow-discrete, background-color 0.3s ease-out, opacity 0.3s ease-out;
+  pointer-events: auto;
+  transition: opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1), visibility 0s allow-discrete;
+}
+
+.modal-backdrop {
+  background-color: transparent;
+}
+
+.modal-box {
+  translate: 0;
+  scale: 1;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0s, visibility 0s;
+}
+
+.modal-toggle:checked + .modal .modal-box {
+  opacity: 1;
+  visibility: visible;
+  transition: opacity 0.15s ease-out 0.3s, visibility 0s 0.3s;
+}
+
+.modal-bottom .modal-box {
+  translate: 0;
 }
 
 /* Make native date / time inputs inherit text color so the format

--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -1,3 +1,73 @@
 class ExpensesController < ApplicationController
-  def index; end
+  before_action :set_expense, only: [ :edit, :update, :destroy ]
+
+  rescue_from ActiveRecord::RecordNotFound do
+    redirect_to expenses_path, alert: 'Expense not found'
+  end
+
+  def index
+    @expenses = Current.user.expenses.includes(:funding_schedule).order(:due_on, :name)
+    @funding_schedules = Current.user.funding_schedules.order(:name)
+  end
+
+  def new
+    @funding_schedules = Current.user.funding_schedules.order(:name)
+    @expense = Current.user.expenses.new(
+      cadence: 'monthly',
+      due_on: Date.current,
+      funding_schedule: @funding_schedules.first
+    )
+  end
+
+  def edit
+    @funding_schedules = Current.user.funding_schedules.order(:name)
+  end
+
+  def create
+    @expense = Current.user.expenses.new(expense_params)
+
+    if @expense.save
+      load_expenses_for_index
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_to expenses_path, notice: 'Expense created' }
+      end
+    else
+      @funding_schedules = Current.user.funding_schedules.order(:name)
+      render :new, status: :unprocessable_content, formats: [ :html ]
+    end
+  end
+
+  def update
+    if @expense.update(expense_params)
+      load_expenses_for_index
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_to expenses_path, notice: 'Expense updated' }
+      end
+    else
+      @funding_schedules = Current.user.funding_schedules.order(:name)
+      render :edit, status: :unprocessable_content, formats: [ :html ]
+    end
+  end
+
+  def destroy
+    @expense.destroy
+    redirect_to expenses_path, notice: 'Expense deleted', status: :see_other
+  end
+
+  private
+
+  def set_expense
+    @expense = Current.user.expenses.find(params.expect(:id))
+  end
+
+  def load_expenses_for_index
+    @expenses = Current.user.expenses.includes(:funding_schedule).order(:due_on, :name)
+    @funding_schedules = Current.user.funding_schedules.order(:name)
+  end
+
+  def expense_params
+    params.expect(expense: [ :name, :amount, :cadence, :due_on, :funding_schedule_id ])
+  end
 end

--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -53,7 +53,11 @@ class ExpensesController < ApplicationController
 
   def destroy
     @expense.destroy
-    redirect_to expenses_path, notice: 'Expense deleted', status: :see_other
+    load_expenses_for_index
+    respond_to do |format|
+      format.turbo_stream { render :update }
+      format.html { redirect_to expenses_path, status: :see_other }
+    end
   end
 
   private

--- a/app/controllers/funding_schedules_controller.rb
+++ b/app/controllers/funding_schedules_controller.rb
@@ -39,7 +39,11 @@ class FundingSchedulesController < ApplicationController
 
   def destroy
     if @funding_schedule.destroy
-      redirect_to settings_path, notice: 'Funding schedule deleted', status: :see_other
+      load_schedules_for_settings
+      respond_to do |format|
+        format.turbo_stream { render :update }
+        format.html { redirect_to settings_path, status: :see_other }
+      end
     else
       redirect_to settings_path, alert: @funding_schedule.errors.full_messages.to_sentence, status: :see_other
     end

--- a/app/controllers/funding_schedules_controller.rb
+++ b/app/controllers/funding_schedules_controller.rb
@@ -38,8 +38,11 @@ class FundingSchedulesController < ApplicationController
   end
 
   def destroy
-    @funding_schedule.destroy
-    redirect_to settings_path, notice: 'Funding schedule deleted', status: :see_other
+    if @funding_schedule.destroy
+      redirect_to settings_path, notice: 'Funding schedule deleted', status: :see_other
+    else
+      redirect_to settings_path, alert: @funding_schedule.errors.full_messages.to_sentence, status: :see_other
+    end
   end
 
   private

--- a/app/controllers/transaction_name_overrides_controller.rb
+++ b/app/controllers/transaction_name_overrides_controller.rb
@@ -21,7 +21,15 @@ class TransactionNameOverridesController < ApplicationController
         format.html { redirect_to transactions_path, status: :see_other }
       end
     else
-      redirect_to safe_return_path, status: :see_other, alert: @override.errors.full_messages.to_sentence
+      message = @override.errors.full_messages.to_sentence
+      # Filter out the unsaved @override that .new added to the association cache,
+      # otherwise applied_override would resolve to it and main_name goes blank.
+      @transaction_name_overrides = Current.user.transaction_name_overrides.to_a.select(&:persisted?)
+      load_transaction_for_drawer
+      respond_to do |format|
+        format.turbo_stream { render :create_failed, status: :unprocessable_content }
+        format.html { redirect_to safe_return_path, status: :see_other, alert: message }
+      end
     end
   end
 

--- a/app/javascript/controllers/toggle_controller.js
+++ b/app/javascript/controllers/toggle_controller.js
@@ -29,6 +29,12 @@ export default class extends Controller {
     }
   }
 
+  // Used by forms inside the toggle so the toggle only collapses on a
+  // successful submit; on validation errors the form stays open.
+  closeOnSuccess(event) {
+    if (event.detail.success) this.close()
+  }
+
   // Delay stream renders targeting our frame so the close animation finishes first
   handleStreamRender(event) {
     if (!this.delayFrameValue) return

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -1,0 +1,55 @@
+class Expense < ApplicationRecord
+  has_paper_trail
+  belongs_to :user
+  belongs_to :funding_schedule
+
+  CADENCES = %w[monthly quarterly semiannual yearly].freeze
+
+  validates :name, presence: true, length: { maximum: 100 }
+  validates :amount, presence: true, numericality: { greater_than: 0 }
+  validates :cadence, inclusion: { in: CADENCES, message: 'must be selected' }
+  validates :due_on, presence: true
+  validate :funding_schedule_belongs_to_user
+
+  # Returns the next date this expense is due on or after `after`.
+  # Not used by the index in Phase 2 — kept for the allocation engine.
+  def next_due_on(after: Date.current)
+    return nil if due_on.blank? || cadence.blank?
+
+    cursor = due_on
+    cursor = advance(cursor) while cursor < after
+    cursor
+  end
+
+  def past_due?
+    due_on.present? && due_on < Date.current
+  end
+
+  private
+
+  def funding_schedule_belongs_to_user
+    return if funding_schedule.blank? || user_id.blank?
+    return if funding_schedule.user_id == user_id
+
+    errors.add(:funding_schedule_id, 'must belong to you')
+  end
+
+  def advance(date)
+    case cadence
+    when 'monthly'    then advance_months(date, 1)
+    when 'quarterly'  then advance_months(date, 3)
+    when 'semiannual' then advance_months(date, 6)
+    when 'yearly'     then advance_months(date, 12)
+    end
+  end
+
+  def advance_months(date, months)
+    next_date = date >> months
+    clamp_day(next_date.year, next_date.month, due_on.day)
+  end
+
+  def clamp_day(year, month, day)
+    last = Date.new(year, month, -1)
+    Date.new(year, month, [ day, last.day ].min)
+  end
+end

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -14,7 +14,7 @@ class Expense < ApplicationRecord
   # Returns the next date this expense is due on or after `after`.
   # Not used by the index in Phase 2 — kept for the allocation engine.
   def next_due_on(after: Date.current)
-    return nil if due_on.blank? || cadence.blank?
+    return nil if due_on.blank? || CADENCES.exclude?(cadence)
 
     cursor = due_on
     cursor = advance(cursor) while cursor < after

--- a/app/models/funding_schedule.rb
+++ b/app/models/funding_schedule.rb
@@ -1,6 +1,7 @@
 class FundingSchedule < ApplicationRecord
   has_paper_trail
   belongs_to :user
+  has_many :expenses, dependent: :restrict_with_error
 
   CADENCES = %w[weekly biweekly semimonthly monthly].freeze
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,7 @@ class User < ApplicationRecord
   has_many :push_subscriptions, dependent: :destroy
   has_many :transaction_name_overrides, dependent: :destroy
   has_many :funding_schedules, dependent: :destroy
+  has_many :expenses, dependent: :destroy
 
   validates :first_name, :last_name, :email_address, presence: true
   validates :email_address, uniqueness: { case_sensitive: false }

--- a/app/views/expenses/_expense.html.erb
+++ b/app/views/expenses/_expense.html.erb
@@ -1,0 +1,52 @@
+<%# locals: (expense:) %>
+
+<div class="relative">
+  <div class="flex items-center px-4 py-3 gap-3 bg-base-200 rounded-xl pr-24">
+    <div class="min-w-0 flex-1">
+      <div class="flex items-baseline gap-2 min-w-0">
+        <p class="font-medium truncate"><%= expense.name %></p>
+        <p class="font-semibold tabular-nums shrink-0"><%= number_to_currency(expense.amount) %></p>
+      </div>
+      <p class="text-sm text-base-content/60 truncate">
+        <%= expense.cadence == 'semiannual' ? 'Semiannually' : expense.cadence.titleize %>
+        · From: <%= expense.funding_schedule.name %>
+        · <%= expense.past_due? ? 'Past due' : 'Next due' %>: <%= expense.due_on.strftime('%b %-d, %Y') %>
+        <% if expense.past_due? %>
+          <span class="badge badge-error badge-sm ml-1">Past due</span>
+        <% end %>
+      </p>
+    </div>
+  </div>
+
+  <%= link_to edit_expense_path(expense),
+        class: "btn btn-ghost btn-sm text-primary absolute right-12 top-1/2 -translate-y-1/2",
+        "aria-label": "Edit #{expense.name}",
+        data: { turbo_frame: "drawer_content", action: "click->drawer#open" } do %>
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+    </svg>
+  <% end %>
+
+  <label for="delete_expense_<%= expense.id %>"
+         class="btn btn-ghost btn-sm text-error absolute right-2 top-1/2 -translate-y-1/2 cursor-pointer"
+         aria-label="Delete <%= expense.name %>">
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+    </svg>
+  </label>
+
+  <input type="checkbox" id="delete_expense_<%= expense.id %>" class="modal-toggle" />
+  <div class="modal modal-bottom sm:modal-middle">
+    <div class="modal-box">
+      <h3 class="text-lg font-bold">Delete expense</h3>
+      <p class="py-4">Are you sure you want to delete "<%= expense.name %>"?</p>
+      <div class="modal-action">
+        <label for="delete_expense_<%= expense.id %>" class="btn">Cancel</label>
+        <%= link_to "Delete", expense_path(expense),
+              data: { turbo_method: :delete, controller: "loading-button", loading_button_text_value: "Deleting..." },
+              class: "btn btn-error" %>
+      </div>
+    </div>
+    <label class="modal-backdrop" for="delete_expense_<%= expense.id %>">Close</label>
+  </div>
+</div>

--- a/app/views/expenses/_form.html.erb
+++ b/app/views/expenses/_form.html.erb
@@ -40,25 +40,33 @@
           Funding schedule<span class="text-error tooltip tooltip-error tooltip-right cursor-pointer" data-tip="Required">•</span>
         </legend>
         <div class="relative">
-          <%= f.collection_select :funding_schedule_id, funding_schedules, :id, :name,
-                { prompt: 'Select a funding schedule' },
-                class: "select w-full #{expense.errors[:funding_schedule_id].any? ? 'select-error' : ''}" %>
+          <div class="flex flex-col gap-2">
+            <% funding_schedules.each do |schedule| %>
+              <label class="flex items-center gap-2 cursor-pointer">
+                <%= f.radio_button :funding_schedule_id, schedule.id, checked: expense.funding_schedule_id == schedule.id, class: "radio radio-sm radio-primary" %>
+                <span class="text-sm"><%= schedule.name %></span>
+              </label>
+            <% end %>
+            <%= link_to "Manage funding schedules", settings_path, class: "link link-primary text-sm mt-1 self-start", data: { turbo_frame: "_top" } %>
+          </div>
           <% if expense.errors[:funding_schedule_id].any? %>
             <p class="absolute left-0 top-full text-error mt-2 text-xs"><%= expense.errors.full_messages_for(:funding_schedule_id).first %></p>
           <% end %>
         </div>
       </fieldset>
 
+      <% cadence_hints = { 'monthly' => 'Every month', 'quarterly' => 'Every 3 months', 'semiannual' => 'Every 6 months', 'yearly' => 'Every 12 months' } %>
+      <% cadence_labels = { 'monthly' => 'Monthly', 'quarterly' => 'Quarterly', 'semiannual' => 'Semiannually', 'yearly' => 'Yearly' } %>
       <fieldset class="fieldset">
         <legend class="fieldset-legend justify-start gap-0">
           Cadence<span class="text-error tooltip tooltip-error tooltip-right cursor-pointer" data-tip="Required">•</span>
         </legend>
         <div class="relative">
-          <div class="flex flex-col gap-2">
+          <div class="flex flex-col items-start gap-2">
             <% Expense::CADENCES.each do |cadence| %>
-              <label class="flex items-center gap-2 cursor-pointer">
+              <label class="flex items-center gap-2 cursor-pointer tooltip tooltip-right" data-tip="<%= cadence_hints[cadence] %>">
                 <%= f.radio_button :cadence, cadence, checked: expense.cadence == cadence, class: "radio radio-sm radio-primary" %>
-                <span class="text-sm"><%= cadence == 'semiannual' ? 'Semiannually (every 6 months)' : cadence.titleize %></span>
+                <span class="text-sm"><%= cadence_labels[cadence] %></span>
               </label>
             <% end %>
           </div>

--- a/app/views/expenses/_form.html.erb
+++ b/app/views/expenses/_form.html.erb
@@ -27,7 +27,7 @@
           <%= f.number_field :amount,
                 value: expense.amount,
                 step: 0.01,
-                min: 0,
+                min: 0.01,
                 class: "input w-full #{expense.errors[:amount].any? ? 'input-error' : ''}" %>
           <% if expense.errors[:amount].any? %>
             <p class="absolute left-0 top-full text-error mt-2 text-xs"><%= expense.errors.full_messages_for(:amount).first %></p>

--- a/app/views/expenses/_form.html.erb
+++ b/app/views/expenses/_form.html.erb
@@ -1,0 +1,93 @@
+<%# locals: (expense:, funding_schedules:) %>
+
+<div class="flex flex-col h-full">
+  <div class="flex items-center justify-between px-5 py-4 border-b border-base-300 shrink-0">
+    <h2 class="font-semibold text-base">
+      <%= expense.persisted? ? "Edit expense" : "New expense" %>
+    </h2>
+    <button type="button" class="btn btn-ghost btn-sm btn-circle" data-action="click->drawer#close" aria-label="Close">
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+      </svg>
+    </button>
+  </div>
+
+  <%= form_with model: expense,
+        html: { novalidate: true },
+        class: "flex flex-col flex-1 min-h-0",
+        data: { action: "turbo:submit-end->drawer#closeOnSuccess" } do |f| %>
+    <div class="overflow-y-auto flex-1 p-5 space-y-6">
+      <%= render "components/text_input", form: f, resource: expense, field: :name, required: true, autofocus: true %>
+
+      <fieldset class="fieldset">
+        <legend class="fieldset-legend justify-start gap-0">
+          Amount<span class="text-error tooltip tooltip-error tooltip-right cursor-pointer" data-tip="Required">•</span>
+        </legend>
+        <div class="relative">
+          <%= f.number_field :amount,
+                value: expense.amount,
+                step: 0.01,
+                min: 0,
+                class: "input w-full #{expense.errors[:amount].any? ? 'input-error' : ''}" %>
+          <% if expense.errors[:amount].any? %>
+            <p class="absolute left-0 top-full text-error mt-2 text-xs"><%= expense.errors.full_messages_for(:amount).first %></p>
+          <% end %>
+        </div>
+      </fieldset>
+
+      <fieldset class="fieldset">
+        <legend class="fieldset-legend justify-start gap-0">
+          Funding schedule<span class="text-error tooltip tooltip-error tooltip-right cursor-pointer" data-tip="Required">•</span>
+        </legend>
+        <div class="relative">
+          <%= f.collection_select :funding_schedule_id, funding_schedules, :id, :name,
+                { prompt: 'Select a funding schedule' },
+                class: "select w-full #{expense.errors[:funding_schedule_id].any? ? 'select-error' : ''}" %>
+          <% if expense.errors[:funding_schedule_id].any? %>
+            <p class="absolute left-0 top-full text-error mt-2 text-xs"><%= expense.errors.full_messages_for(:funding_schedule_id).first %></p>
+          <% end %>
+        </div>
+      </fieldset>
+
+      <fieldset class="fieldset">
+        <legend class="fieldset-legend justify-start gap-0">
+          Cadence<span class="text-error tooltip tooltip-error tooltip-right cursor-pointer" data-tip="Required">•</span>
+        </legend>
+        <div class="relative">
+          <div class="flex flex-col gap-2">
+            <% Expense::CADENCES.each do |cadence| %>
+              <label class="flex items-center gap-2 cursor-pointer">
+                <%= f.radio_button :cadence, cadence, checked: expense.cadence == cadence, class: "radio radio-sm radio-primary" %>
+                <span class="text-sm"><%= cadence == 'semiannual' ? 'Semiannually (every 6 months)' : cadence.titleize %></span>
+              </label>
+            <% end %>
+          </div>
+          <% if expense.errors[:cadence].any? %>
+            <p class="absolute left-0 top-full text-error mt-2 text-xs"><%= expense.errors.full_messages_for(:cadence).first %></p>
+          <% end %>
+        </div>
+      </fieldset>
+
+      <fieldset class="fieldset">
+        <legend class="fieldset-legend justify-start gap-0">
+          Next due<span class="text-error tooltip tooltip-error tooltip-right cursor-pointer" data-tip="Required">•</span>
+        </legend>
+        <div class="relative">
+          <%= f.date_field :due_on,
+                value: expense.due_on,
+                class: "input w-full #{expense.errors[:due_on].any? ? 'input-error' : ''}" %>
+          <% if expense.errors[:due_on].any? %>
+            <p class="absolute left-0 top-full text-error mt-2 text-xs"><%= expense.errors.full_messages_for(:due_on).first %></p>
+          <% end %>
+        </div>
+      </fieldset>
+    </div>
+
+    <div class="border-t border-base-300 p-5 shrink-0">
+      <div class="flex gap-2">
+        <%= f.submit class: "btn btn-primary flex-1", data: { controller: "loading-button" } %>
+        <button type="button" class="btn btn-ghost flex-1" data-action="click->drawer#close">Cancel</button>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/expenses/_list.html.erb
+++ b/app/views/expenses/_list.html.erb
@@ -10,7 +10,7 @@
           </svg>
           <p class="mt-4 text-base-content/60">Add a funding schedule first</p>
           <p class="mt-1 text-sm text-base-content/40">Expenses are funded by your paychecks — set one up to get started.</p>
-          <%= link_to "Go to settings", settings_path, class: "btn btn-primary btn-sm mt-4" %>
+          <%= link_to "Go to settings", settings_path, class: "btn btn-primary btn-sm mt-4", data: { turbo_frame: "_top" } %>
         </div>
       </div>
     </div>

--- a/app/views/expenses/_list.html.erb
+++ b/app/views/expenses/_list.html.erb
@@ -1,0 +1,27 @@
+<%# locals: (expenses:, funding_schedules:) %>
+
+<%= turbo_frame_tag "expenses", class: "block w-full max-w-240 mt-4 px-4" do %>
+  <% if funding_schedules.none? %>
+    <div class="card card-lg bg-base-100 shadow-glow">
+      <div class="card-body">
+        <div class="text-center py-8">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 mx-auto text-base-content/40" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <p class="mt-4 text-base-content/60">Add a funding schedule first</p>
+          <p class="mt-1 text-sm text-base-content/40">Expenses are funded by your paychecks — set one up to get started.</p>
+          <%= link_to "Go to settings", settings_path, class: "btn btn-primary btn-sm mt-4" %>
+        </div>
+      </div>
+    </div>
+  <% else %>
+    <div class="space-y-2">
+      <% expenses.each do |expense| %>
+        <%= render expense %>
+      <% end %>
+      <p class="text-sm text-base-content/40 text-center py-6 <%= 'hidden' if expenses.any? %>">
+        No expenses yet.
+      </p>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/expenses/_list.html.erb
+++ b/app/views/expenses/_list.html.erb
@@ -14,14 +14,23 @@
         </div>
       </div>
     </div>
-  <% else %>
+  <% elsif expenses.any? %>
     <div class="space-y-2">
       <% expenses.each do |expense| %>
         <%= render expense %>
       <% end %>
-      <p class="text-sm text-base-content/40 text-center py-6 <%= 'hidden' if expenses.any? %>">
-        No expenses yet.
-      </p>
+    </div>
+  <% else %>
+    <div class="card card-lg bg-base-100 shadow-glow">
+      <div class="card-body">
+        <div class="text-center py-8">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 mx-auto text-base-content/40" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
+          </svg>
+          <p class="mt-4 text-base-content/60">No expenses yet</p>
+          <p class="mt-1 text-sm text-base-content/40">Tap + to add your first one.</p>
+        </div>
+      </div>
     </div>
   <% end %>
 <% end %>

--- a/app/views/expenses/create.turbo_stream.erb
+++ b/app/views/expenses/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "expenses" do %>
+  <%= render "expenses/list", expenses: @expenses, funding_schedules: @funding_schedules %>
+<% end %>

--- a/app/views/expenses/edit.html.erb
+++ b/app/views/expenses/edit.html.erb
@@ -1,0 +1,6 @@
+<% content_for :title, "Edit expense" %>
+<% content_for :drawer_frame_provided, true %>
+
+<%= turbo_frame_tag "drawer_content" do %>
+  <%= render "form", expense: @expense, funding_schedules: @funding_schedules %>
+<% end %>

--- a/app/views/expenses/index.html.erb
+++ b/app/views/expenses/index.html.erb
@@ -1,19 +1,19 @@
 <% content_for :title, "Expenses" %>
 
 <div class="flex flex-col items-center pb-10">
-  <h2 class="text-2xl font-bold mt-10 w-full max-w-240 px-4">Expenses</h2>
-
-  <div class="card card-lg bg-base-100 mt-4 w-full max-w-240 shadow-glow">
-    <div class="card-body">
-      <div class="text-center py-8">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 mx-auto text-base-content/40" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" />
+  <div class="w-full max-w-240 mt-10 px-4 flex items-center justify-between gap-3">
+    <h2 class="text-2xl font-bold">Expenses</h2>
+    <% if @funding_schedules.any? %>
+      <%= link_to new_expense_path,
+            class: "btn btn-primary btn-sm btn-circle",
+            "aria-label": "New expense",
+            data: { turbo_frame: "drawer_content", action: "click->drawer#open" } do %>
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M12 4v16m8-8H4" />
         </svg>
-
-        <p class="mt-4 text-base-content/60">No expenses yet</p>
-
-        <p class="mt-1 text-sm text-base-content/40">Expenses will appear here once they are set up</p>
-      </div>
-    </div>
+      <% end %>
+    <% end %>
   </div>
+
+  <%= render "list", expenses: @expenses, funding_schedules: @funding_schedules %>
 </div>

--- a/app/views/expenses/new.html.erb
+++ b/app/views/expenses/new.html.erb
@@ -1,0 +1,6 @@
+<% content_for :title, "New expense" %>
+<% content_for :drawer_frame_provided, true %>
+
+<%= turbo_frame_tag "drawer_content" do %>
+  <%= render "form", expense: @expense, funding_schedules: @funding_schedules %>
+<% end %>

--- a/app/views/expenses/update.turbo_stream.erb
+++ b/app/views/expenses/update.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "expenses" do %>
+  <%= render "expenses/list", expenses: @expenses, funding_schedules: @funding_schedules %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -71,6 +71,10 @@
          data-action="click->drawer#close">
     </div>
 
+    <%# Toast container — outside any turbo-frame so turbo_stream actions can %>
+    <%# prepend toasts that aren't discarded by frame-scoped responses. %>
+    <div id="toasts" class="contents"></div>
+
     <%# Drawer panel — bg matches <html> so iOS PWA doesn't tint the safe area %>
     <%# with a different shade when the drawer fills the viewport. %>
     <div data-drawer-target="panel"

--- a/app/views/transaction_name_overrides/create_failed.turbo_stream.erb
+++ b/app/views/transaction_name_overrides/create_failed.turbo_stream.erb
@@ -1,0 +1,10 @@
+<% if @transaction %>
+  <%= turbo_stream.replace "drawer_content" do %>
+    <%= turbo_frame_tag "drawer_content" do %>
+      <%= render "transactions/transaction_detail",
+          transaction: @transaction,
+          transaction_name_override: @transaction_name_override,
+          failed_override: @override %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/transactions/_transaction_detail.html.erb
+++ b/app/views/transactions/_transaction_detail.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (transaction:, transaction_name_override:) %>
+<%# locals: (transaction:, transaction_name_override:, failed_override: nil) %>
 <% main_name = transaction_name_override ? transaction_name_override.replacement_name : (transaction.merchant_name.presence || transaction.name) %>
 <% show_original = main_name != transaction.name %>
 
@@ -42,8 +42,8 @@
           <p class="text-sm text-base-content/50 mt-0.5 truncate"><%= transaction.name %></p>
         <% end %>
 
-        <div data-toggle-target="content" class="hidden mt-3">
-          <% if transaction_name_override %>
+        <div data-toggle-target="content" class="<%= 'hidden' unless failed_override %> mt-3">
+          <% if transaction_name_override&.persisted? %>
             <div class="bg-base-200 rounded-xl p-3">
               <div class="flex items-center justify-between gap-3">
                 <div class="text-sm">
@@ -71,22 +71,34 @@
               <p class="text-xs text-base-content/50 mb-3">"<%= transaction.merchant_name %>" was automatically set by your bank. Set an override below to rename it.</p>
             <% end %>
 
-            <%= form_with url: transaction_name_overrides_path, scope: :transaction_name_override, data: { action: "submit->toggle#close" } do |f| %>
+            <% match_type_value = failed_override&.match_type || "exact" %>
+            <%= form_with url: transaction_name_overrides_path, scope: :transaction_name_override, html: { novalidate: true }, data: { action: "turbo:submit-end->toggle#closeOnSuccess" } do |f| %>
               <%= hidden_field_tag :transaction_id, transaction.id %>
 
               <div class="flex gap-4 mb-3">
-                <%= render "components/radio_button", form: f, field: :match_type, value: "exact", label: "Exact match", checked: true %>
-                <%= render "components/radio_button", form: f, field: :match_type, value: "contains", label: "Contains" %>
+                <%= render "components/radio_button", form: f, field: :match_type, value: "exact", label: "Exact match", checked: match_type_value == "exact" %>
+                <%= render "components/radio_button", form: f, field: :match_type, value: "contains", label: "Contains", checked: match_type_value == "contains" %>
               </div>
 
               <div class="space-y-2 mb-3">
                 <div>
                   <label class="label py-0 mb-1"><span class="label-text text-xs text-base-content/60">Match text</span></label>
-                  <%= f.text_field :match_text, value: transaction.name, class: "input input-bordered input-sm w-full" %>
+                  <%= f.text_field :match_text,
+                        value: failed_override&.match_text || transaction.name,
+                        class: "input input-bordered input-sm w-full #{'input-error' if failed_override&.errors&.[](:match_text)&.any?}" %>
+                  <% if failed_override&.errors&.[](:match_text)&.any? %>
+                    <p class="text-error text-xs mt-1"><%= failed_override.errors.full_messages_for(:match_text).first %></p>
+                  <% end %>
                 </div>
                 <div>
                   <label class="label py-0 mb-1"><span class="label-text text-xs text-base-content/60">Rename to</span></label>
-                  <%= f.text_field :replacement_name, class: "input input-bordered input-sm w-full", placeholder: "New display name" %>
+                  <%= f.text_field :replacement_name,
+                        value: failed_override&.replacement_name,
+                        class: "input input-bordered input-sm w-full #{'input-error' if failed_override&.errors&.[](:replacement_name)&.any?}",
+                        placeholder: "New display name" %>
+                  <% if failed_override&.errors&.[](:replacement_name)&.any? %>
+                    <p class="text-error text-xs mt-1"><%= failed_override.errors.full_messages_for(:replacement_name).first %></p>
+                  <% end %>
                 </div>
               </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
   resources :transactions, only: [ :index, :show ]
   resources :transaction_name_overrides, only: [ :create, :destroy ]
   resources :funding_schedules, only: [ :new, :create, :edit, :update, :destroy ]
-  resources :expenses, only: [ :index ]
+  resources :expenses
   resources :goals, only: [ :index ]
   resource :profile, only: [ :show, :edit, :update ] do
     get :edit_security

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
   resources :transactions, only: [ :index, :show ]
   resources :transaction_name_overrides, only: [ :create, :destroy ]
   resources :funding_schedules, only: [ :new, :create, :edit, :update, :destroy ]
-  resources :expenses
+  resources :expenses, only: [ :index, :new, :create, :edit, :update, :destroy ]
   resources :goals, only: [ :index ]
   resource :profile, only: [ :show, :edit, :update ] do
     get :edit_security

--- a/db/migrate/20260614025740_create_expenses.rb
+++ b/db/migrate/20260614025740_create_expenses.rb
@@ -1,0 +1,14 @@
+class CreateExpenses < ActiveRecord::Migration[8.1]
+  def change
+    create_table :expenses, id: :uuid do |t|
+      t.references :user, null: false, foreign_key: true, type: :uuid
+      t.references :funding_schedule, null: false, foreign_key: true, type: :uuid
+      t.string :name, null: false
+      t.decimal :amount, precision: 10, scale: 2, null: false
+      t.string :cadence, null: false
+      t.date :due_on, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_12_033429) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_14_025740) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -49,6 +49,19 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_12_033429) do
     t.uuid "user_id", null: false
     t.index ["plaid_item_id"], name: "index_banks_on_plaid_item_id", unique: true
     t.index ["user_id"], name: "index_banks_on_user_id", unique: true
+  end
+
+  create_table "expenses", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.decimal "amount", precision: 10, scale: 2, null: false
+    t.string "cadence", null: false
+    t.datetime "created_at", null: false
+    t.date "due_on", null: false
+    t.uuid "funding_schedule_id", null: false
+    t.string "name", null: false
+    t.datetime "updated_at", null: false
+    t.uuid "user_id", null: false
+    t.index ["funding_schedule_id"], name: "index_expenses_on_funding_schedule_id"
+    t.index ["user_id"], name: "index_expenses_on_user_id"
   end
 
   create_table "funding_schedules", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -281,6 +294,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_12_033429) do
 
   add_foreign_key "bank_accounts", "banks"
   add_foreign_key "banks", "users"
+  add_foreign_key "expenses", "funding_schedules"
+  add_foreign_key "expenses", "users"
   add_foreign_key "funding_schedules", "users"
   add_foreign_key "push_subscriptions", "users"
   add_foreign_key "sessions", "users"

--- a/package-lock.json
+++ b/package-lock.json
@@ -127,6 +127,29 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
@@ -671,7 +694,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",

--- a/test/controllers/expenses_controller_test.rb
+++ b/test/controllers/expenses_controller_test.rb
@@ -1,0 +1,205 @@
+require 'test_helper'
+
+class ExpensesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:johndoe)
+    @schedule = funding_schedules(:paycheck)
+  end
+
+  test 'index requires authentication' do
+    get expenses_url
+
+    assert_redirected_to new_session_path
+  end
+
+  test 'index renders the expenses list' do
+    sign_in_as(@user)
+
+    get expenses_url
+
+    assert_response :success
+    assert_select 'p', text: 'Netflix'
+    assert_select 'p', text: 'Car insurance'
+  end
+
+  test 'index without funding schedules shows the setup pointer' do
+    sign_in_as(@user)
+    @user.expenses.destroy_all
+    @user.funding_schedules.destroy_all
+
+    get expenses_url
+
+    assert_response :success
+    assert_select 'p', text: /Add a funding schedule first/i
+    assert_select 'a[href=?]', settings_path, text: /go to settings/i
+  end
+
+  test 'new renders the form' do
+    sign_in_as(@user)
+
+    get new_expense_url
+
+    assert_response :success
+    assert_select 'form'
+  end
+
+  test 'create persists an expense' do
+    sign_in_as(@user)
+
+    assert_difference '@user.expenses.count', 1 do
+      post expenses_url, params: {
+        expense: {
+          name: 'Spotify',
+          amount: '9.99',
+          cadence: 'monthly',
+          due_on: '2026-03-15',
+          funding_schedule_id: @schedule.id
+        }
+      }
+    end
+
+    assert_redirected_to expenses_path
+    expense = @user.expenses.order(:created_at).last
+    assert_equal 'Spotify', expense.name
+    assert_equal 9.99, expense.amount.to_f
+    assert_equal 'monthly', expense.cadence
+    assert_equal Date.new(2026, 3, 15), expense.due_on
+  end
+
+  test 'create responds with turbo_stream that replaces the expenses frame' do
+    sign_in_as(@user)
+
+    post expenses_url,
+         params: {
+           expense: {
+             name: 'Spotify',
+             amount: '9.99',
+             cadence: 'monthly',
+             due_on: '2026-03-15',
+             funding_schedule_id: @schedule.id
+           }
+         },
+         headers: { Accept: 'text/vnd.turbo-stream.html' }
+
+    assert_response :success
+    assert_match(/turbo-stream action="replace" target="expenses"/, response.body)
+    assert_match(/Spotify/, response.body)
+  end
+
+  test 'create re-renders new on invalid input' do
+    sign_in_as(@user)
+
+    assert_no_difference '@user.expenses.count' do
+      post expenses_url, params: {
+        expense: { name: '', amount: '9.99', cadence: 'monthly', due_on: '2026-03-15', funding_schedule_id: @schedule.id }
+      }
+    end
+
+    assert_response :unprocessable_content
+  end
+
+  test 'create with turbo_stream accept and invalid input returns html form' do
+    sign_in_as(@user)
+
+    post expenses_url,
+         params: {
+           expense: { name: '', amount: '9.99', cadence: 'monthly', due_on: '2026-03-15', funding_schedule_id: @schedule.id }
+         },
+         headers: { Accept: 'text/vnd.turbo-stream.html' }
+
+    assert_response :unprocessable_content
+    assert_select 'form'
+  end
+
+  test 'create rejects a funding schedule that belongs to another user' do
+    sign_in_as(@user)
+    other_schedule = funding_schedules(:janes_paycheck)
+
+    assert_no_difference '@user.expenses.count' do
+      post expenses_url, params: {
+        expense: {
+          name: 'Spotify',
+          amount: '9.99',
+          cadence: 'monthly',
+          due_on: '2026-03-15',
+          funding_schedule_id: other_schedule.id
+        }
+      }
+    end
+
+    assert_response :unprocessable_content
+  end
+
+  test 'edit renders the form for the user-owned expense' do
+    sign_in_as(@user)
+
+    get edit_expense_url(expenses(:netflix))
+
+    assert_response :success
+    assert_select 'form'
+  end
+
+  test 'edit redirects when the expense belongs to another user' do
+    sign_in_as(@user)
+
+    get edit_expense_url(expenses(:janes_rent))
+
+    assert_redirected_to expenses_path
+  end
+
+  test 'update persists changes' do
+    sign_in_as(@user)
+    expense = expenses(:netflix)
+
+    patch expense_url(expense), params: {
+      expense: {
+        name: 'Netflix Premium',
+        amount: '22.99',
+        cadence: 'monthly',
+        due_on: '2026-02-14',
+        funding_schedule_id: @schedule.id
+      }
+    }
+
+    assert_redirected_to expenses_path
+    expense.reload
+    assert_equal 'Netflix Premium', expense.name
+    assert_equal 22.99, expense.amount.to_f
+  end
+
+  test 'update with turbo_stream accept and invalid input returns html form' do
+    sign_in_as(@user)
+    expense = expenses(:netflix)
+
+    patch expense_url(expense),
+          params: {
+            expense: { name: '', amount: '22.99', cadence: 'monthly', due_on: '2026-02-14', funding_schedule_id: @schedule.id }
+          },
+          headers: { Accept: 'text/vnd.turbo-stream.html' }
+
+    assert_response :unprocessable_content
+    assert_select 'form'
+  end
+
+  test 'destroy removes the expense' do
+    sign_in_as(@user)
+    expense = expenses(:netflix)
+
+    assert_difference '@user.expenses.count', -1 do
+      delete expense_url(expense)
+    end
+
+    assert_redirected_to expenses_path
+  end
+
+  test 'destroy redirects when the expense belongs to another user' do
+    sign_in_as(@user)
+    expense = expenses(:janes_rent)
+
+    assert_no_difference 'Expense.count' do
+      delete expense_url(expense)
+    end
+
+    assert_redirected_to expenses_path
+  end
+end

--- a/test/controllers/funding_schedules_controller_test.rb
+++ b/test/controllers/funding_schedules_controller_test.rb
@@ -164,7 +164,7 @@ class FundingSchedulesControllerTest < ActionDispatch::IntegrationTest
 
   test 'destroy removes the schedule' do
     sign_in_as(@user)
-    schedule = funding_schedules(:paycheck)
+    schedule = funding_schedules(:side_gig) # no expenses attached
 
     assert_difference '@user.funding_schedules.count', -1 do
       delete funding_schedule_url(schedule)
@@ -182,5 +182,17 @@ class FundingSchedulesControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_redirected_to settings_path
+  end
+
+  test 'destroy is blocked when expenses are tied to the schedule' do
+    sign_in_as(@user)
+    schedule = funding_schedules(:paycheck) # has Netflix + Car insurance fixtures
+
+    assert_no_difference 'FundingSchedule.count' do
+      delete funding_schedule_url(schedule)
+    end
+
+    follow_redirect!
+    assert_match(/dependent expenses/i, flash[:alert] || @response.body)
   end
 end

--- a/test/controllers/settings_controller_test.rb
+++ b/test/controllers/settings_controller_test.rb
@@ -176,6 +176,7 @@ class SettingsControllerTest < ActionDispatch::IntegrationTest
 
   test 'show shows empty state when user has no funding schedules' do
     sign_in_as(@user)
+    @user.expenses.destroy_all
     @user.funding_schedules.destroy_all
 
     get settings_path

--- a/test/controllers/transaction_name_overrides_controller_test.rb
+++ b/test/controllers/transaction_name_overrides_controller_test.rb
@@ -45,6 +45,24 @@ class TransactionNameOverridesControllerTest < ActionDispatch::IntegrationTest
     assert_match(/can't be blank/, flash[:alert])
   end
 
+  test 'create with turbo_stream accept and invalid input replaces drawer_content with form errors' do
+    sign_in_as(@user)
+    transaction = Transaction.create!(name: 'NETFLIX', amount: 5.50, bank_account: bank_accounts(:chase_checking))
+
+    assert_no_difference '@user.transaction_name_overrides.count' do
+      post transaction_name_overrides_url,
+           params: {
+             transaction_id: transaction.id,
+             transaction_name_override: { match_type: 'exact', match_text: '', replacement_name: 'Amazon' }
+           },
+           headers: { Accept: 'text/vnd.turbo-stream.html' }
+    end
+
+    assert_response :unprocessable_content
+    assert_match(/turbo-stream action="replace" target="drawer_content"/, response.body)
+    assert_match(/Match text can&#39;t be blank/, response.body)
+  end
+
   test 'destroy removes the override' do
     sign_in_as(@user)
     override = transaction_name_overrides(:test_exact)

--- a/test/fixtures/expenses.yml
+++ b/test/fixtures/expenses.yml
@@ -1,0 +1,23 @@
+netflix:
+  user: johndoe
+  funding_schedule: paycheck
+  name: Netflix
+  amount: 15.99
+  cadence: monthly
+  due_on: 2026-02-14
+
+car_insurance:
+  user: johndoe
+  funding_schedule: paycheck
+  name: Car insurance
+  amount: 480.00
+  cadence: semiannual
+  due_on: 2026-04-01
+
+janes_rent:
+  user: janedoe
+  funding_schedule: janes_paycheck
+  name: Rent
+  amount: 1500.00
+  cadence: monthly
+  due_on: 2026-02-01

--- a/test/models/expense_test.rb
+++ b/test/models/expense_test.rb
@@ -1,0 +1,94 @@
+require 'test_helper'
+
+class ExpenseTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:johndoe)
+    @schedule = funding_schedules(:paycheck)
+  end
+
+  def build(**attrs)
+    @user.expenses.new(
+      funding_schedule: @schedule,
+      name: 'Spotify',
+      amount: 9.99,
+      cadence: 'monthly',
+      due_on: Date.new(2026, 2, 14),
+      **attrs
+    )
+  end
+
+  test 'is valid with required fields' do
+    assert build.valid?
+  end
+
+  test 'requires name' do
+    assert_includes build(name: nil).tap(&:valid?).errors[:name], "can't be blank"
+  end
+
+  test 'requires amount' do
+    assert_includes build(amount: nil).tap(&:valid?).errors[:amount], "can't be blank"
+  end
+
+  test 'requires positive amount' do
+    assert_includes build(amount: 0).tap(&:valid?).errors[:amount], 'must be greater than 0'
+  end
+
+  test 'requires cadence in allowed set' do
+    assert_includes build(cadence: 'fortnightly').tap(&:valid?).errors[:cadence], 'must be selected'
+  end
+
+  test 'requires due_on' do
+    assert_includes build(due_on: nil).tap(&:valid?).errors[:due_on], "can't be blank"
+  end
+
+  test 'rejects a funding schedule that belongs to another user' do
+    other_schedule = funding_schedules(:janes_paycheck)
+    expense = build(funding_schedule: other_schedule)
+
+    assert_not expense.valid?
+    assert_includes expense.errors[:funding_schedule_id], 'must belong to you'
+  end
+
+  test 'monthly next_due_on rolls forward and clamps short months' do
+    expense = build(cadence: 'monthly', due_on: Date.new(2026, 1, 31))
+
+    assert_equal Date.new(2026, 2, 28), expense.next_due_on(after: Date.new(2026, 2, 1))
+    assert_equal Date.new(2026, 3, 31), expense.next_due_on(after: Date.new(2026, 3, 1))
+  end
+
+  test 'quarterly next_due_on rolls forward by 3 months' do
+    expense = build(cadence: 'quarterly', due_on: Date.new(2026, 1, 15))
+
+    assert_equal Date.new(2026, 4, 15), expense.next_due_on(after: Date.new(2026, 4, 1))
+    assert_equal Date.new(2026, 7, 15), expense.next_due_on(after: Date.new(2026, 5, 1))
+  end
+
+  test 'semiannual next_due_on rolls forward and clamps Aug 31 to Feb 28' do
+    expense = build(cadence: 'semiannual', due_on: Date.new(2025, 8, 31))
+
+    assert_equal Date.new(2026, 2, 28), expense.next_due_on(after: Date.new(2026, 1, 1))
+    assert_equal Date.new(2026, 8, 31), expense.next_due_on(after: Date.new(2026, 3, 1))
+  end
+
+  test 'yearly next_due_on clamps Feb 29 leap day to Feb 28 next year' do
+    expense = build(cadence: 'yearly', due_on: Date.new(2024, 2, 29))
+
+    assert_equal Date.new(2025, 2, 28), expense.next_due_on(after: Date.new(2025, 1, 1))
+    assert_equal Date.new(2026, 2, 28), expense.next_due_on(after: Date.new(2026, 1, 1))
+    assert_equal Date.new(2028, 2, 29), expense.next_due_on(after: Date.new(2027, 3, 1))
+  end
+
+  test 'next_due_on returns the stored due_on when after is in the past' do
+    expense = build(cadence: 'monthly', due_on: Date.new(2026, 2, 14))
+
+    assert_equal Date.new(2026, 2, 14), expense.next_due_on(after: Date.new(2026, 1, 1))
+  end
+
+  test 'past_due is true when due_on is before today' do
+    travel_to Date.new(2026, 3, 1) do
+      assert build(due_on: Date.new(2026, 2, 14)).past_due?
+      assert_not build(due_on: Date.new(2026, 3, 1)).past_due?
+      assert_not build(due_on: Date.new(2026, 4, 1)).past_due?
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Phase 2 of the Simple-style Expenses feature. An `Expense` captures a recurring obligation — name, amount, cadence, due date — and ties to one `FundingSchedule`. CRUD only; the allocation engine and transaction-to-expense matching come in Phase 3.

- Cadences: **monthly**, **quarterly**, **semiannual**, **yearly**. Last-day-of-month clamp for short months (Aug 31 semiannual rolls to Feb 28, Feb 29 yearly rolls to Feb 28 in non-leap years).
- Phase 2 explicitly does **not** auto-roll `due_on` by cadence. Real bills sometimes draft late, so the stored date is what's displayed; rows render a "Past due" badge when `due_on < today`. The auto-advance happens in Phase 3 when a transaction is matched to the expense.
- Top-level `/expenses` page with the same drawer-based new/edit flow as funding schedules. Empty state when the user has no funding schedules points to `/settings` to set one up.
- `FundingSchedule#destroy` is now blocked by dependent expenses (`restrict_with_error`) so a paycheck can't be deleted while bills are still tied to it.

## Polish + bug fixes picked up along the way

- **Expenses empty state** matches the funding-schedules card style (centered icon + message + hint).
- **Funding schedule picker** on the expense form is now radio buttons (matches the cadence radios) with a "Manage funding schedules" link to `/settings`. Tooltips on cadence labels ("Every 6 months" etc.) instead of inline parentheticals.
- **No toast on delete** for expenses or funding schedules; the row just disappears via a turbo_stream replacing the list frame.
- **Date input** in the funding-schedule form defaults to today and uses the page's color-scheme so Safari doesn't render the format hint in default blue under dark theme.
- **iOS confirm-modal animation** now mimics the drawer overlay: 300ms opacity fade on the backdrop, modal-box held invisible until the backdrop has fully arrived, no scale/translate "pop", and daisyUI's page-background swap (which lightened the page in dark mode before re-darkening) is disabled. Modal backdrop bg matches the drawer's `bg-black/50`.
- **Transaction name override form** validation: failure no longer renders Turbo's "Content missing" or leaves the Save button spinning. It now responds 422 with a turbo_stream that re-renders the drawer with `input-error` styling on the bad fields, inline per-field messages, and the values the user typed pre-filled. `toggle#closeOnSuccess` keeps the form open on failure but still collapses cleanly on success. Filtered the unsaved override out of the in-memory association cache so the transaction's main name doesn't go blank when the failed override matched the transaction name.

## Test plan
- [ ] `/expenses` with no funding schedules → empty state with "Add a funding schedule first" → button to `/settings`
- [ ] Add a schedule, return to `/expenses` → `+` button appears
- [ ] Create a monthly expense with `due_on` set to last week → row shows the date with a "Past due" badge and sorts above future-due rows
- [ ] Create a semiannual expense due Aug 31 → list shows that exact date
- [ ] Edit an expense, change cadence to yearly → row updates with the new cadence label
- [ ] Delete an expense via the modal → row disappears, no toast, no full page swap
- [ ] Try to delete a funding schedule that has expenses from `/settings` → blocked with an alert, schedule remains
- [ ] Delete the expenses, then delete the schedule → succeeds
- [ ] On `/transactions`, open a transaction, click edit name, submit empty → form stays open with inline error, Save button is fresh
- [ ] Same flow but enter valid values → drawer updates with the applied override, toggle collapses
- [ ] Open and close a delete confirm modal → backdrop fades smoothly with no flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)