### PR TITLE
Bump DB pool to cover worker dyno's actual connection demand

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -24,7 +24,6 @@ default: &default
   # dispatcher + Solid Cable polling, so set DATABASE_POOL only there to override
   # without bumping Puma threads on web (Heroku config vars are app-wide).
   max_connections: <%= ENV.fetch("DATABASE_POOL") { ENV.fetch("RAILS_MAX_THREADS", 5) } %>
-  checkout_timeout: <%= ENV.fetch("DB_CHECKOUT_TIMEOUT", 5) %>
 
 
 development:

--- a/config/database.yml
+++ b/config/database.yml
@@ -15,14 +15,12 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  # Pool must cover every thread that may acquire a connection on this process:
-  # Puma threads on web, Solid Queue worker + dispatcher threads on worker, plus
-  # Solid Cable's polling thread (single-DB mode). DB_POOL lets the worker dyno
-  # set a higher pool than the web dyno without bumping RAILS_MAX_THREADS.
-  # Previously this was set under the wrong key (`max_connections`) which was
-  # silently ignored, leaving the pool at AR's default of 5 and starving the
-  # worker dyno.
-  pool: <%= ENV.fetch("DB_POOL") { ENV.fetch("RAILS_MAX_THREADS", 5).to_i + 2 } %>
+  # max_connections must cover every thread that may acquire a connection on
+  # this process: Puma threads on web; Solid Queue worker + dispatcher threads
+  # plus Solid Cable's polling thread (single-DB mode) on the worker. DB_POOL
+  # lets the worker dyno set a larger pool than the web dyno without bumping
+  # RAILS_MAX_THREADS (which also drives Puma).
+  max_connections: <%= ENV.fetch("DB_POOL") { ENV.fetch("RAILS_MAX_THREADS", 5).to_i + 2 } %>
   checkout_timeout: <%= ENV.fetch("DB_CHECKOUT_TIMEOUT", 5) %>
 
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -15,11 +15,14 @@
 default: &default
   adapter: postgresql
   encoding: unicode
+  # For details on connection pooling, see Rails configuration guide
+  # https://guides.rubyonrails.org/configuring.html#database-pooling
+  #
   # max_connections defaults to RAILS_MAX_THREADS (the Rails-generator default
   # and the Heroku buildpack convention), which sizes Puma correctly on the
-  # web dyno. The worker dyno's real demand comes from Solid Queue threads +
-  # dispatcher + Solid Cable polling, not Puma, so set DB_POOL only there
-  # to override without affecting Puma's thread count on web.
+  # web dyno. The worker dyno has no Puma but does run Solid Queue threads +
+  # dispatcher + Solid Cable polling, so set DB_POOL only there to override
+  # without bumping Puma threads on web (Heroku config vars are app-wide).
   max_connections: <%= ENV.fetch("DB_POOL") { ENV.fetch("RAILS_MAX_THREADS", 5) } %>
   checkout_timeout: <%= ENV.fetch("DB_CHECKOUT_TIMEOUT", 5) %>
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -21,9 +21,9 @@ default: &default
   # max_connections defaults to RAILS_MAX_THREADS (the Rails-generator default
   # and the Heroku buildpack convention), which sizes Puma correctly on the
   # web dyno. The worker dyno has no Puma but does run Solid Queue threads +
-  # dispatcher + Solid Cable polling, so set DB_POOL only there to override
+  # dispatcher + Solid Cable polling, so set DATABASE_POOL only there to override
   # without bumping Puma threads on web (Heroku config vars are app-wide).
-  max_connections: <%= ENV.fetch("DB_POOL") { ENV.fetch("RAILS_MAX_THREADS", 5) } %>
+  max_connections: <%= ENV.fetch("DATABASE_POOL") { ENV.fetch("RAILS_MAX_THREADS", 5) } %>
   checkout_timeout: <%= ENV.fetch("DB_CHECKOUT_TIMEOUT", 5) %>
 
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -15,9 +15,15 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  # For details on connection pooling, see Rails configuration guide
-  # https://guides.rubyonrails.org/configuring.html#database-pooling
-  max_connections: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  # Pool must cover every thread that may acquire a connection on this process:
+  # Puma threads on web, Solid Queue worker + dispatcher threads on worker, plus
+  # Solid Cable's polling thread (single-DB mode). DB_POOL lets the worker dyno
+  # set a higher pool than the web dyno without bumping RAILS_MAX_THREADS.
+  # Previously this was set under the wrong key (`max_connections`) which was
+  # silently ignored, leaving the pool at AR's default of 5 and starving the
+  # worker dyno.
+  pool: <%= ENV.fetch("DB_POOL") { ENV.fetch("RAILS_MAX_THREADS", 5).to_i + 2 } %>
+  checkout_timeout: <%= ENV.fetch("DB_CHECKOUT_TIMEOUT", 5) %>
 
 
 development:

--- a/config/database.yml
+++ b/config/database.yml
@@ -15,12 +15,11 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  # max_connections must cover every thread that may acquire a connection on
-  # this process: Puma threads on web; Solid Queue worker + dispatcher threads
-  # plus Solid Cable's polling thread (single-DB mode) on the worker. DB_POOL
-  # lets the worker dyno set a larger pool than the web dyno without bumping
-  # RAILS_MAX_THREADS (which also drives Puma).
-  max_connections: <%= ENV.fetch("DB_POOL") { ENV.fetch("RAILS_MAX_THREADS", 5).to_i + 2 } %>
+  # Pool size for this process. Must cover every thread that may acquire a
+  # connection: Puma threads on web; Solid Queue worker + dispatcher threads
+  # plus Solid Cable's polling thread (single-DB mode) on the worker. Set
+  # DB_POOL per dyno (e.g., 5 on web, 7 on worker for a 3-thread queue config).
+  max_connections: <%= ENV.fetch("DB_POOL", 5) %>
   checkout_timeout: <%= ENV.fetch("DB_CHECKOUT_TIMEOUT", 5) %>
 
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -15,11 +15,12 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  # Pool size for this process. Must cover every thread that may acquire a
-  # connection: Puma threads on web; Solid Queue worker + dispatcher threads
-  # plus Solid Cable's polling thread (single-DB mode) on the worker. Set
-  # DB_POOL per dyno (e.g., 5 on web, 7 on worker for a 3-thread queue config).
-  max_connections: <%= ENV.fetch("DB_POOL", 5) %>
+  # max_connections defaults to RAILS_MAX_THREADS (the Rails-generator default
+  # and the Heroku buildpack convention), which sizes Puma correctly on the
+  # web dyno. The worker dyno's real demand comes from Solid Queue threads +
+  # dispatcher + Solid Cable polling, not Puma, so set DB_POOL only there
+  # to override without affecting Puma's thread count on web.
+  max_connections: <%= ENV.fetch("DB_POOL") { ENV.fetch("RAILS_MAX_THREADS", 5) } %>
   checkout_timeout: <%= ENV.fetch("DB_CHECKOUT_TIMEOUT", 5) %>
 
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -18,11 +18,13 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   #
-  # max_connections defaults to RAILS_MAX_THREADS (the Rails-generator default
-  # and the Heroku buildpack convention), which sizes Puma correctly on the
-  # web dyno. The worker dyno has no Puma but does run Solid Queue threads +
-  # dispatcher + Solid Cable polling, so set DATABASE_POOL only there to override
-  # without bumping Puma threads on web (Heroku config vars are app-wide).
+  # Resolution: DATABASE_POOL > RAILS_MAX_THREADS > 5. The default
+  # (RAILS_MAX_THREADS / 5) matches the Rails generator and sizes Puma
+  # correctly. Set DATABASE_POOL when a process needs more connections
+  # than Puma threads — e.g., the worker dyno running Solid Queue +
+  # dispatcher + Solid Cable polling. Note: Heroku config vars are
+  # app-wide, so setting DATABASE_POOL lifts both dynos — the worker
+  # needs the headroom, the web dyno just ends up over-provisioned.
   max_connections: <%= ENV.fetch("DATABASE_POOL") { ENV.fetch("RAILS_MAX_THREADS", 5) } %>
 
 


### PR DESCRIPTION
## Summary

(I previously claimed the original `max_connections:` key was a typo. It wasn't — Rails 7.2+ renamed `pool:` to `max_connections:` and deprecated `pool:` ([activerecord-8.1.3/lib/active_record/database_configurations/hash_config.rb:84](https://github.com/rails/rails/blob/v8.1.3/activerecord/lib/active_record/database_configurations/hash_config.rb#L84)). The generator was correct.)

The actual problem is the **value**. The fallback was 5 — which is *exactly* the worker dyno's concurrent connection demand:

- 3 Solid Queue worker threads (`config/queue.yml`: `threads: 3`)
- 1 dispatcher polling thread
- 1 Solid Cable polling thread (single-DB mode, per `cable.yml`)

= 5 connections. Any burst that opens a transient connection hits the ceiling and throws:

> ActiveRecord::ConnectionTimeoutError: could not obtain a connection from the pool within 5.000 seconds…

## What changed

- Keep `max_connections:` defaulting to `RAILS_MAX_THREADS` (Rails-generator default, sizes Puma correctly on the web dyno).
- Add a `DATABASE_POOL` env var as a per-dyno escape hatch — the worker has no Puma but does run Solid Queue + dispatcher + Solid Cable polling, so its pool needs to be sized independently. Named to match `DATABASE_URL`.
- Resolution order: `DATABASE_POOL` → `RAILS_MAX_THREADS` → `5`.

## Heroku settings to apply alongside this PR

```bash
heroku config:set DATABASE_POOL=7 --app paychecq-staging
heroku restart --app paychecq-staging
```

Heroku config vars are app-wide, so this lifts pool to 7 on both web and worker. That's fine — web with pool 7 (Puma 3 + cable 1 = 4 used) is happily over-provisioned, and worker (3 + 1 + 1 = 5 used) gets the 2 spare it needs.

essential-0 connection budget (20 cap):
- Web: ~7 pool used
- Worker: ~7 pool used
- ~14/20 total, leaves 6 for migrations + psql sessions

## Test plan
- [ ] Deploy, set `DATABASE_POOL=7`, restart
- [ ] `heroku pg:info` shows higher steady-state but well under 20
- [ ] Trigger a burst (multiple Plaid webhooks / job runs) — no more ConnectionTimeoutError

🤖 Generated with [Claude Code](https://claude.com/claude-code)