### PR TITLE
Allocation engine

### DIFF
--- a/app/jobs/process_funding_events_job.rb
+++ b/app/jobs/process_funding_events_job.rb
@@ -6,9 +6,14 @@ class ProcessFundingEventsJob < ApplicationJob
       schedule.materialize_events_through(end_date: Date.current)
     end
 
+    # Iterate via .each with explicit chronological order — propose_for
+    # builds on the expense's existing allocations, so events must be
+    # processed oldest-first. find_each batches by primary key (UUID) and
+    # would silently shuffle the order.
     FundingEvent.where(processed_at: nil)
                 .where(occurs_on: ..Date.current)
-                .find_each do |event|
+                .order(:occurs_on, :created_at)
+                .each do |event|
       AllocationEngine.propose_for(event)
     rescue StandardError => error
       Rails.logger.error("AllocationEngine.propose_for failed for funding_event=#{event.id}: #{error.message}")

--- a/app/jobs/process_funding_events_job.rb
+++ b/app/jobs/process_funding_events_job.rb
@@ -15,7 +15,12 @@ class ProcessFundingEventsJob < ApplicationJob
       Appsignal.send_error(error)
     end
 
-    User.joins(:expenses).distinct.find_each do |user|
+    # Only walk users who actually have pending allocations to fund. Avoids
+    # acquiring a row lock per user every hour when nothing changed.
+    User.joins(expenses: :allocations)
+        .where(allocations: { funded_at: nil })
+        .distinct
+        .find_each do |user|
       AllocationEngine.fund_pending_for(user)
     rescue StandardError => error
       Rails.logger.error("AllocationEngine.fund_pending_for failed for user=#{user.id}: #{error.message}")

--- a/app/jobs/process_funding_events_job.rb
+++ b/app/jobs/process_funding_events_job.rb
@@ -1,0 +1,25 @@
+class ProcessFundingEventsJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    FundingSchedule.find_each do |schedule|
+      schedule.materialize_events_through(end_date: Date.current)
+    end
+
+    FundingEvent.where(processed_at: nil)
+                .where(occurs_on: ..Date.current)
+                .find_each do |event|
+      AllocationEngine.propose_for(event)
+    rescue StandardError => error
+      Rails.logger.error("AllocationEngine.propose_for failed for funding_event=#{event.id}: #{error.message}")
+      Appsignal.send_error(error)
+    end
+
+    User.joins(:expenses).distinct.find_each do |user|
+      AllocationEngine.fund_pending_for(user)
+    rescue StandardError => error
+      Rails.logger.error("AllocationEngine.fund_pending_for failed for user=#{user.id}: #{error.message}")
+      Appsignal.send_error(error)
+    end
+  end
+end

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -1,0 +1,8 @@
+class Allocation < ApplicationRecord
+  has_paper_trail
+  belongs_to :funding_event
+  belongs_to :expense
+
+  validates :amount, presence: true, numericality: { greater_than: 0 }
+  validates :expense_id, uniqueness: { scope: :funding_event_id }
+end

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -2,6 +2,7 @@ class Expense < ApplicationRecord
   has_paper_trail
   belongs_to :user
   belongs_to :funding_schedule
+  has_many :allocations, dependent: :destroy
 
   CADENCES = %w[monthly quarterly semiannual yearly].freeze
 
@@ -23,6 +24,18 @@ class Expense < ApplicationRecord
 
   def past_due?
     due_on.present? && due_on < Date.current
+  end
+
+  # Sum of funded allocations only — pending allocations don't count toward
+  # the bucket. Phase 3b will subtract on transaction linking.
+  def bucket_balance
+    allocations.where.not(funded_at: nil).sum(:amount)
+  end
+
+  # An expense is off-track when any allocation has been proposed but not
+  # yet funded (the balance hasn't caught up).
+  def off_track?
+    allocations.exists?(funded_at: nil)
   end
 
   private

--- a/app/models/funding_event.rb
+++ b/app/models/funding_event.rb
@@ -1,0 +1,8 @@
+class FundingEvent < ApplicationRecord
+  has_paper_trail
+  belongs_to :funding_schedule
+  has_many :allocations, dependent: :destroy
+
+  validates :occurs_on, presence: true
+  validates :occurs_on, uniqueness: { scope: :funding_schedule_id }
+end

--- a/app/models/funding_schedule.rb
+++ b/app/models/funding_schedule.rb
@@ -21,12 +21,14 @@ class FundingSchedule < ApplicationRecord
   # Find-or-creates a FundingEvent for every occurrence between the last
   # materialized event (or start_date) through end_date. Idempotent.
   def materialize_events_through(end_date:)
+    return [] if start_date.blank? || cadence.blank?
+
     last = funding_events.maximum(:occurs_on)
-    cursor = last ? next_occurrences(count: 1, after: last + 1).first : start_date
+    cursor = last ? advance(last) : start_date
     events = []
     while cursor && cursor <= end_date
       events << funding_events.create_or_find_by!(occurs_on: cursor)
-      cursor = next_occurrences(count: 1, after: cursor + 1).first
+      cursor = advance(cursor)
     end
     events
   end

--- a/app/models/funding_schedule.rb
+++ b/app/models/funding_schedule.rb
@@ -23,8 +23,7 @@ class FundingSchedule < ApplicationRecord
   def materialize_events_through(end_date:)
     return [] if start_date.blank? || cadence.blank?
 
-    last = funding_events.maximum(:occurs_on)
-    cursor = last ? advance(last) : start_date
+    cursor = first_unmaterialized_occurrence
     events = []
     while cursor && cursor <= end_date
       events << funding_events.create_or_find_by!(occurs_on: cursor)
@@ -61,6 +60,18 @@ class FundingSchedule < ApplicationRecord
   end
 
   private
+
+  # Where materialize_events_through should pick up from. If older events
+  # exist, advance from the latest; if start_date was moved forward past
+  # advance(last), clamp to start_date so we never backfill into the user's
+  # revised "this is when paychecks begin" window.
+  def first_unmaterialized_occurrence
+    last = funding_events.maximum(:occurs_on)
+    return start_date unless last
+
+    candidate = advance(last)
+    [ candidate, start_date ].max
+  end
 
   def second_day_differs_from_start_day
     return if second_day_of_month.blank? || start_date.blank?

--- a/app/models/funding_schedule.rb
+++ b/app/models/funding_schedule.rb
@@ -18,7 +18,7 @@ class FundingSchedule < ApplicationRecord
 
   def semimonthly? = cadence == 'semimonthly'
 
-  # Find-or-creates a FundingEvent for every occurrence between the last
+  # Finds or creates a FundingEvent for every occurrence between the last
   # materialized event (or start_date) through end_date. Idempotent.
   def materialize_events_through(end_date:)
     return [] if start_date.blank? || cadence.blank?
@@ -31,6 +31,21 @@ class FundingSchedule < ApplicationRecord
       cursor = advance(cursor)
     end
     events
+  end
+
+  # Returns the number of occurrences this schedule fires between `after`
+  # (inclusive) and `through` (inclusive). Unbounded in count — use when you
+  # need an accurate count, not when you just need the next N occurrences.
+  def occurrence_count_between(after:, through:)
+    return 0 if start_date.blank? || cadence.blank? || through < after
+
+    count = 0
+    cursor = first_occurrence_on_or_after(after)
+    while cursor && cursor <= through
+      count += 1
+      cursor = advance(cursor)
+    end
+    count
   end
 
   # Returns the next `count` dates this schedule fires on or after `after`.

--- a/app/models/funding_schedule.rb
+++ b/app/models/funding_schedule.rb
@@ -2,6 +2,7 @@ class FundingSchedule < ApplicationRecord
   has_paper_trail
   belongs_to :user
   has_many :expenses, dependent: :restrict_with_error
+  has_many :funding_events, dependent: :destroy
 
   CADENCES = %w[weekly biweekly semimonthly monthly].freeze
 
@@ -16,6 +17,19 @@ class FundingSchedule < ApplicationRecord
   validate :second_day_differs_from_start_day, if: :semimonthly?
 
   def semimonthly? = cadence == 'semimonthly'
+
+  # Find-or-creates a FundingEvent for every occurrence between the last
+  # materialized event (or start_date) through end_date. Idempotent.
+  def materialize_events_through(end_date:)
+    last = funding_events.maximum(:occurs_on)
+    cursor = last ? next_occurrences(count: 1, after: last + 1).first : start_date
+    events = []
+    while cursor && cursor <= end_date
+      events << funding_events.create_or_find_by!(occurs_on: cursor)
+      cursor = next_occurrences(count: 1, after: cursor + 1).first
+    end
+    events
+  end
 
   # Returns the next `count` dates this schedule fires on or after `after`.
   def next_occurrences(count: 3, after: Date.current)

--- a/app/services/allocation_engine.rb
+++ b/app/services/allocation_engine.rb
@@ -49,7 +49,11 @@ class AllocationEngine
   end
 
   # Look-ahead split: remaining-amount / paychecks-remaining-until-due.
-  # Past-due falls to "this paycheck covers the rest" (clamped to 1).
+  # Note: when the expense's due_on is already in the past, next_due_on
+  # rolls forward past as_of, so paychecks_remaining is still > 0 and the
+  # normal split applies. The clamp-to-1 below only kicks in if the
+  # schedule has no occurrences in [as_of, next_due] at all (e.g., schedule
+  # hasn't started yet) — in that case this single paycheck covers the rest.
   private_class_method def self.compute_proposed_amount(expense, schedule, as_of:)
     remaining = expense.amount - expense.allocations.sum(:amount)
     return 0 if remaining <= 0

--- a/app/services/allocation_engine.rb
+++ b/app/services/allocation_engine.rb
@@ -24,7 +24,9 @@ class AllocationEngine
   # the same already_funded baseline.
   def self.fund_pending_for(user)
     user.with_lock do
-      available = user.bank_accounts.sum(:available_balance)
+      # PG's SUM() returns NULL when every input row is NULL; AR returns 0
+      # only when there are no rows at all. Coalesce so we don't compare nil.
+      available = user.bank_accounts.sum(:available_balance) || 0
       already_funded = Allocation.joins(:expense)
                                  .where(expenses: { user_id: user.id })
                                  .where.not(funded_at: nil)

--- a/app/services/allocation_engine.rb
+++ b/app/services/allocation_engine.rb
@@ -19,23 +19,30 @@ class AllocationEngine
   end
 
   # Walk this user's pending allocations in due-date order and flip
-  # funded_at when current available_balance can back them.
+  # funded_at when current available_balance can back them. Serialized
+  # per-user with a row lock so concurrent runs can't double-fund off
+  # the same already_funded baseline.
   def self.fund_pending_for(user)
-    available = user.bank_accounts.sum(:available_balance)
-    already_funded = Allocation.joins(:expense)
-                               .where(expenses: { user_id: user.id })
-                               .where.not(funded_at: nil)
-                               .sum(:amount)
+    user.with_lock do
+      available = user.bank_accounts.sum(:available_balance)
+      already_funded = Allocation.joins(:expense)
+                                 .where(expenses: { user_id: user.id })
+                                 .where.not(funded_at: nil)
+                                 .sum(:amount)
 
-    pending = Allocation.joins(:expense)
-                        .where(expenses: { user_id: user.id }, funded_at: nil)
-                        .order('expenses.due_on ASC, expenses.created_at ASC')
+      pending = Allocation.joins(:expense)
+                          .where(expenses: { user_id: user.id }, funded_at: nil)
+                          .order('expenses.due_on ASC, expenses.created_at ASC')
 
-    pending.find_each do |allocation|
-      next unless available >= already_funded + allocation.amount
+      # NOTE: .each (not find_each) because find_each ignores custom ORDER BY
+      # — it batches by primary key. Pending allocations per user are bounded
+      # (handful per active cycle), so loading them all is fine.
+      pending.each do |allocation|
+        next unless available >= already_funded + allocation.amount
 
-      allocation.update!(funded_at: Time.current)
-      already_funded += allocation.amount
+        allocation.update!(funded_at: Time.current)
+        already_funded += allocation.amount
+      end
     end
   end
 

--- a/app/services/allocation_engine.rb
+++ b/app/services/allocation_engine.rb
@@ -55,8 +55,7 @@ class AllocationEngine
     return 0 if remaining <= 0
 
     next_due = expense.next_due_on(after: as_of)
-    paychecks_remaining = schedule.next_occurrences(count: 100, after: as_of)
-                                  .count { |d| d <= next_due }
+    paychecks_remaining = schedule.occurrence_count_between(after: as_of, through: next_due)
     paychecks_remaining = 1 if paychecks_remaining.zero?
 
     (remaining / paychecks_remaining).round(2)

--- a/app/services/allocation_engine.rb
+++ b/app/services/allocation_engine.rb
@@ -1,0 +1,55 @@
+class AllocationEngine
+  # Idempotently propose Allocation rows for one funding event — one per
+  # expense on the schedule, created with funded_at: nil. Setting
+  # processed_at signals "we've considered this event."
+  def self.propose_for(funding_event)
+    return if funding_event.processed_at.present?
+
+    schedule = funding_event.funding_schedule
+    schedule.expenses.find_each do |expense|
+      amount = compute_proposed_amount(expense, schedule, as_of: funding_event.occurs_on)
+      next if amount <= 0
+
+      Allocation.create_or_find_by!(funding_event: funding_event, expense: expense) do |a|
+        a.amount = amount
+      end
+    end
+
+    funding_event.update!(processed_at: Time.current)
+  end
+
+  # Walk this user's pending allocations in due-date order and flip
+  # funded_at when current available_balance can back them.
+  def self.fund_pending_for(user)
+    available = user.bank_accounts.sum(:available_balance)
+    already_funded = Allocation.joins(:expense)
+                               .where(expenses: { user_id: user.id })
+                               .where.not(funded_at: nil)
+                               .sum(:amount)
+
+    pending = Allocation.joins(:expense)
+                        .where(expenses: { user_id: user.id }, funded_at: nil)
+                        .order('expenses.due_on ASC, expenses.created_at ASC')
+
+    pending.find_each do |allocation|
+      next unless available >= already_funded + allocation.amount
+
+      allocation.update!(funded_at: Time.current)
+      already_funded += allocation.amount
+    end
+  end
+
+  # Look-ahead split: remaining-amount / paychecks-remaining-until-due.
+  # Past-due falls to "this paycheck covers the rest" (clamped to 1).
+  private_class_method def self.compute_proposed_amount(expense, schedule, as_of:)
+    remaining = expense.amount - expense.allocations.sum(:amount)
+    return 0 if remaining <= 0
+
+    next_due = expense.next_due_on(after: as_of)
+    paychecks_remaining = schedule.next_occurrences(count: 100, after: as_of)
+                                  .count { |d| d <= next_due }
+    paychecks_remaining = 1 if paychecks_remaining.zero?
+
+    (remaining / paychecks_remaining).round(2)
+  end
+end

--- a/app/views/expenses/_expense.html.erb
+++ b/app/views/expenses/_expense.html.erb
@@ -22,7 +22,8 @@
       %>
       <div class="flex items-center gap-2 mt-1">
         <progress class="progress <%= off_track ? 'progress-warning' : 'progress-primary' %> h-1.5 flex-1"
-                  value="<%= percent %>" max="100"></progress>
+                  value="<%= percent %>" max="100"
+                  aria-label="<%= expense.name %> funded <%= percent %>%"></progress>
         <span class="text-xs text-base-content/60 tabular-nums shrink-0">
           <%= number_to_currency(bucket) %> / <%= number_to_currency(expense.amount) %>
         </span>

--- a/app/views/expenses/_expense.html.erb
+++ b/app/views/expenses/_expense.html.erb
@@ -15,14 +15,18 @@
           <span class="badge badge-error badge-sm ml-1">Past due</span>
         <% end %>
       </p>
-      <% percent = expense.amount.positive? ? [ (expense.bucket_balance / expense.amount * 100).to_i, 100 ].min : 0 %>
+      <%
+        bucket = expense.bucket_balance
+        off_track = expense.off_track?
+        percent = expense.amount.positive? ? [ (bucket / expense.amount * 100).to_i, 100 ].min : 0
+      %>
       <div class="flex items-center gap-2 mt-1">
-        <progress class="progress <%= expense.off_track? ? 'progress-warning' : 'progress-primary' %> h-1.5 flex-1"
+        <progress class="progress <%= off_track ? 'progress-warning' : 'progress-primary' %> h-1.5 flex-1"
                   value="<%= percent %>" max="100"></progress>
         <span class="text-xs text-base-content/60 tabular-nums shrink-0">
-          <%= number_to_currency(expense.bucket_balance) %> / <%= number_to_currency(expense.amount) %>
+          <%= number_to_currency(bucket) %> / <%= number_to_currency(expense.amount) %>
         </span>
-        <% if expense.off_track? %>
+        <% if off_track %>
           <span class="badge badge-warning badge-xs shrink-0">Off track</span>
         <% end %>
       </div>

--- a/app/views/expenses/_expense.html.erb
+++ b/app/views/expenses/_expense.html.erb
@@ -15,6 +15,17 @@
           <span class="badge badge-error badge-sm ml-1">Past due</span>
         <% end %>
       </p>
+      <% percent = expense.amount.positive? ? [ (expense.bucket_balance / expense.amount * 100).to_i, 100 ].min : 0 %>
+      <div class="flex items-center gap-2 mt-1">
+        <progress class="progress <%= expense.off_track? ? 'progress-warning' : 'progress-primary' %> h-1.5 flex-1"
+                  value="<%= percent %>" max="100"></progress>
+        <span class="text-xs text-base-content/60 tabular-nums shrink-0">
+          <%= number_to_currency(expense.bucket_balance) %> / <%= number_to_currency(expense.amount) %>
+        </span>
+        <% if expense.off_track? %>
+          <span class="badge badge-warning badge-xs shrink-0">Off track</span>
+        <% end %>
+      </div>
     </div>
   </div>
 

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -13,8 +13,14 @@ staging:
   clear_solid_queue_finished_jobs:
     class: ClearSolidQueueFinishedJobsJob
     schedule: every hour at minute 12
+  process_funding_events:
+    class: ProcessFundingEventsJob
+    schedule: every hour
 
 production:
   clear_solid_queue_finished_jobs:
     class: ClearSolidQueueFinishedJobsJob
     schedule: every hour at minute 12
+  process_funding_events:
+    class: ProcessFundingEventsJob
+    schedule: every hour

--- a/db/migrate/20260615052452_create_funding_events_and_allocations.rb
+++ b/db/migrate/20260615052452_create_funding_events_and_allocations.rb
@@ -1,0 +1,24 @@
+class CreateFundingEventsAndAllocations < ActiveRecord::Migration[8.1]
+  def change
+    create_table :funding_events, id: :uuid do |t|
+      t.references :funding_schedule, null: false, foreign_key: true, type: :uuid
+      t.date :occurs_on, null: false
+      t.datetime :processed_at
+
+      t.timestamps
+
+      t.index [ :funding_schedule_id, :occurs_on ], unique: true
+    end
+
+    create_table :allocations, id: :uuid do |t|
+      t.references :funding_event, null: false, foreign_key: true, type: :uuid
+      t.references :expense, null: false, foreign_key: true, type: :uuid
+      t.decimal :amount, precision: 10, scale: 2, null: false
+      t.datetime :funded_at
+
+      t.timestamps
+
+      t.index [ :funding_event_id, :expense_id ], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_14_025740) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_15_052452) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
+
+  create_table "allocations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.decimal "amount", precision: 10, scale: 2, null: false
+    t.datetime "created_at", null: false
+    t.uuid "expense_id", null: false
+    t.datetime "funded_at"
+    t.uuid "funding_event_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["expense_id"], name: "index_allocations_on_expense_id"
+    t.index ["funding_event_id", "expense_id"], name: "index_allocations_on_funding_event_id_and_expense_id", unique: true
+    t.index ["funding_event_id"], name: "index_allocations_on_funding_event_id"
+  end
 
   create_table "bank_accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "account_subtype"
@@ -62,6 +74,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_14_025740) do
     t.uuid "user_id", null: false
     t.index ["funding_schedule_id"], name: "index_expenses_on_funding_schedule_id"
     t.index ["user_id"], name: "index_expenses_on_user_id"
+  end
+
+  create_table "funding_events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.uuid "funding_schedule_id", null: false
+    t.date "occurs_on", null: false
+    t.datetime "processed_at"
+    t.datetime "updated_at", null: false
+    t.index ["funding_schedule_id", "occurs_on"], name: "index_funding_events_on_funding_schedule_id_and_occurs_on", unique: true
+    t.index ["funding_schedule_id"], name: "index_funding_events_on_funding_schedule_id"
   end
 
   create_table "funding_schedules", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -292,10 +314,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_14_025740) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
+  add_foreign_key "allocations", "expenses"
+  add_foreign_key "allocations", "funding_events"
   add_foreign_key "bank_accounts", "banks"
   add_foreign_key "banks", "users"
   add_foreign_key "expenses", "funding_schedules"
   add_foreign_key "expenses", "users"
+  add_foreign_key "funding_events", "funding_schedules"
   add_foreign_key "funding_schedules", "users"
   add_foreign_key "push_subscriptions", "users"
   add_foreign_key "sessions", "users"

--- a/test/fixtures/allocations.yml
+++ b/test/fixtures/allocations.yml
@@ -1,0 +1,11 @@
+netflix_first:
+  funding_event: paycheck_first
+  expense: netflix
+  amount: 8.00
+  funded_at: 2026-01-01T08:00:00Z
+
+netflix_second_pending:
+  funding_event: paycheck_second
+  expense: netflix
+  amount: 7.99
+  funded_at:

--- a/test/fixtures/funding_events.yml
+++ b/test/fixtures/funding_events.yml
@@ -1,0 +1,7 @@
+paycheck_first:
+  funding_schedule: paycheck
+  occurs_on: 2026-01-01
+
+paycheck_second:
+  funding_schedule: paycheck
+  occurs_on: 2026-01-15

--- a/test/jobs/process_funding_events_job_test.rb
+++ b/test/jobs/process_funding_events_job_test.rb
@@ -33,6 +33,53 @@ class ProcessFundingEventsJobTest < ActiveJob::TestCase
     end
   end
 
+  test 'continues to next event when propose_for raises, logs + reports' do
+    original_propose = AllocationEngine.method(:propose_for)
+    original_send_error = Appsignal.method(:send_error)
+
+    @schedule.materialize_events_through(end_date: Date.new(2026, 1, 16))
+    raising_event = FundingEvent.find_by!(occurs_on: Date.new(2026, 1, 1))
+
+    AllocationEngine.define_singleton_method(:propose_for) do |event|
+      raise StandardError, 'simulated failure' if event == raising_event
+
+      original_propose.call(event)
+    end
+    reported = nil
+    Appsignal.define_singleton_method(:send_error) { |err| reported = err }
+
+    travel_to(Date.new(2026, 1, 16)) { ProcessFundingEventsJob.perform_now }
+
+    assert_kind_of StandardError, reported
+    other = FundingEvent.find_by!(occurs_on: Date.new(2026, 1, 15))
+    assert other.processed_at.present?, 'non-raising event should still get processed'
+  ensure
+    AllocationEngine.define_singleton_method(:propose_for, original_propose) if original_propose
+    Appsignal.define_singleton_method(:send_error, original_send_error) if original_send_error
+  end
+
+  test 'continues to next user when fund_pending_for raises, logs + reports' do
+    original_fund = AllocationEngine.method(:fund_pending_for)
+    original_send_error = Appsignal.method(:send_error)
+    failing_user = @user
+
+    AllocationEngine.define_singleton_method(:fund_pending_for) do |user|
+      raise StandardError, 'simulated failure' if user == failing_user
+
+      original_fund.call(user)
+    end
+    reported = nil
+    Appsignal.define_singleton_method(:send_error) { |err| reported = err }
+
+    assert_nothing_raised do
+      travel_to(Date.new(2026, 1, 16)) { ProcessFundingEventsJob.perform_now }
+    end
+    assert_kind_of StandardError, reported
+  ensure
+    AllocationEngine.define_singleton_method(:fund_pending_for, original_fund) if original_fund
+    Appsignal.define_singleton_method(:send_error, original_send_error) if original_send_error
+  end
+
   test 'flips previously-pending allocations on a later run when balance catches up' do
     @user.bank_accounts.update_all(available_balance: 0) # rubocop:disable Rails/SkipsModelValidations
 

--- a/test/jobs/process_funding_events_job_test.rb
+++ b/test/jobs/process_funding_events_job_test.rb
@@ -1,0 +1,52 @@
+require 'test_helper'
+
+class ProcessFundingEventsJobTest < ActiveJob::TestCase
+  setup do
+    @user = users(:johndoe)
+    @user.expenses.destroy_all
+    @user.funding_schedules.destroy_all
+
+    @schedule = @user.funding_schedules.create!(name: 'Paycheck', cadence: 'biweekly', start_date: Date.new(2026, 1, 1))
+    @expense = @user.expenses.create!(name: 'Netflix', amount: 15.99, cadence: 'monthly', due_on: Date.new(2026, 1, 29), funding_schedule: @schedule)
+  end
+
+  test 'materializes, proposes, and funds end-to-end' do
+    travel_to Date.new(2026, 1, 16) do
+      ProcessFundingEventsJob.perform_now
+    end
+
+    events = @schedule.funding_events.order(:occurs_on)
+    assert_equal [ Date.new(2026, 1, 1), Date.new(2026, 1, 15) ], events.map(&:occurs_on)
+    assert events.all? { |e| e.processed_at.present? }, 'every materialized event should be marked processed'
+
+    funded = @expense.allocations.where.not(funded_at: nil)
+    assert_equal 2, funded.count, 'both allocations should be funded with the bank balance covering them'
+  end
+
+  test 'is a no-op on the second run (idempotent)' do
+    travel_to Date.new(2026, 1, 16) do
+      ProcessFundingEventsJob.perform_now
+
+      assert_no_difference [ 'FundingEvent.count', 'Allocation.count' ] do
+        ProcessFundingEventsJob.perform_now
+      end
+    end
+  end
+
+  test 'flips previously-pending allocations on a later run when balance catches up' do
+    @user.bank_accounts.update_all(available_balance: 0) # rubocop:disable Rails/SkipsModelValidations
+
+    travel_to Date.new(2026, 1, 16) do
+      ProcessFundingEventsJob.perform_now
+    end
+
+    assert @expense.allocations.exists?(funded_at: nil), 'allocations should be pending after first run'
+
+    @user.bank_accounts.update_all(available_balance: 100) # rubocop:disable Rails/SkipsModelValidations
+    travel_to Date.new(2026, 1, 16) do
+      ProcessFundingEventsJob.perform_now
+    end
+
+    assert @expense.allocations.where(funded_at: nil).none?, 'no allocations should remain pending after second run'
+  end
+end

--- a/test/models/allocation_test.rb
+++ b/test/models/allocation_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+class AllocationTest < ActiveSupport::TestCase
+  setup do
+    @event = funding_events(:paycheck_first)
+    @expense = expenses(:car_insurance) # netflix already has an allocation for paycheck_first
+  end
+
+  test 'is valid with required fields' do
+    allocation = Allocation.new(funding_event: @event, expense: @expense, amount: 10.00)
+
+    assert allocation.valid?
+  end
+
+  test 'requires amount' do
+    allocation = Allocation.new(funding_event: @event, expense: @expense)
+
+    assert_not allocation.valid?
+    assert_includes allocation.errors[:amount], "can't be blank"
+  end
+
+  test 'requires positive amount' do
+    allocation = Allocation.new(funding_event: @event, expense: @expense, amount: 0)
+
+    assert_not allocation.valid?
+    assert_includes allocation.errors[:amount], 'must be greater than 0'
+  end
+
+  test 'enforces unique expense per funding_event' do
+    duplicate = Allocation.new(funding_event: funding_events(:paycheck_first), expense: expenses(:netflix), amount: 5)
+
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:expense_id], 'has already been taken'
+  end
+end

--- a/test/models/expense_test.rb
+++ b/test/models/expense_test.rb
@@ -84,6 +84,24 @@ class ExpenseTest < ActiveSupport::TestCase
     assert_equal Date.new(2026, 2, 14), expense.next_due_on(after: Date.new(2026, 1, 1))
   end
 
+  test 'bucket_balance sums only funded allocations' do
+    expense = expenses(:netflix)
+
+    assert_equal 8.00, expense.bucket_balance.to_f
+  end
+
+  test 'off_track? is true when any allocation is pending' do
+    expense = expenses(:netflix) # fixture has a pending allocation on paycheck_second
+
+    assert expense.off_track?
+  end
+
+  test 'off_track? is false when all allocations are funded' do
+    expense = expenses(:car_insurance)
+
+    assert_not expense.off_track?
+  end
+
   test 'past_due is true when due_on is before today' do
     travel_to Date.new(2026, 3, 1) do
       assert build(due_on: Date.new(2026, 2, 14)).past_due?

--- a/test/models/funding_event_test.rb
+++ b/test/models/funding_event_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+class FundingEventTest < ActiveSupport::TestCase
+  setup { @schedule = funding_schedules(:paycheck) }
+
+  test 'is valid with required fields' do
+    event = FundingEvent.new(funding_schedule: @schedule, occurs_on: Date.new(2026, 2, 1))
+
+    assert event.valid?
+  end
+
+  test 'requires occurs_on' do
+    event = FundingEvent.new(funding_schedule: @schedule)
+
+    assert_not event.valid?
+    assert_includes event.errors[:occurs_on], "can't be blank"
+  end
+
+  test 'enforces unique occurs_on per funding_schedule' do
+    duplicate = FundingEvent.new(funding_schedule: @schedule, occurs_on: funding_events(:paycheck_first).occurs_on)
+
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:occurs_on], 'has already been taken'
+  end
+
+  test 'allows same occurs_on for different funding_schedule' do
+    event = FundingEvent.new(funding_schedule: funding_schedules(:side_gig), occurs_on: funding_events(:paycheck_first).occurs_on)
+
+    assert event.valid?
+  end
+
+  test 'destroys allocations on destroy' do
+    event = funding_events(:paycheck_first)
+
+    assert_difference 'Allocation.count', -1 do
+      event.destroy
+    end
+  end
+end

--- a/test/models/funding_schedule_test.rb
+++ b/test/models/funding_schedule_test.rb
@@ -119,6 +119,21 @@ class FundingScheduleTest < ActiveSupport::TestCase
     assert_equal [ Date.new(2026, 1, 15), Date.new(2026, 1, 22) ], events.map(&:occurs_on)
   end
 
+  test 'materialize_events_through does not backfill before a moved-forward start_date' do
+    schedule = @user.funding_schedules.create!(name: 'Moved', cadence: 'weekly', start_date: Date.new(2026, 1, 1))
+    # Older events exist from the original window.
+    schedule.funding_events.create!(occurs_on: Date.new(2026, 1, 1))
+    schedule.funding_events.create!(occurs_on: Date.new(2026, 1, 8))
+
+    # User moves start_date forward to 2026-02-01.
+    schedule.update!(start_date: Date.new(2026, 2, 1))
+
+    events = schedule.materialize_events_through(end_date: Date.new(2026, 2, 5))
+
+    # No backfill into 1/15, 1/22, 1/29 — picks up at the new start_date.
+    assert_equal [ Date.new(2026, 2, 1) ], events.map(&:occurs_on)
+  end
+
   test 'materialize_events_through is idempotent' do
     schedule = @user.funding_schedules.create!(name: 'Idem', cadence: 'weekly', start_date: Date.new(2026, 1, 1))
 

--- a/test/models/funding_schedule_test.rb
+++ b/test/models/funding_schedule_test.rb
@@ -100,6 +100,35 @@ class FundingScheduleTest < ActiveSupport::TestCase
     assert_equal [ Date.new(2026, 1, 15), Date.new(2026, 1, 31), Date.new(2026, 2, 15), Date.new(2026, 2, 28) ], dates
   end
 
+  test 'materialize_events_through creates events from start_date through end_date when clean' do
+    schedule = @user.funding_schedules.create!(name: 'New paycheck', cadence: 'weekly', start_date: Date.new(2026, 1, 1))
+
+    events = schedule.materialize_events_through(end_date: Date.new(2026, 1, 22))
+
+    occurs_on = events.map(&:occurs_on)
+    assert_equal [ Date.new(2026, 1, 1), Date.new(2026, 1, 8), Date.new(2026, 1, 15), Date.new(2026, 1, 22) ], occurs_on
+  end
+
+  test 'materialize_events_through picks up where the last event left off' do
+    schedule = @user.funding_schedules.create!(name: 'Picked up', cadence: 'weekly', start_date: Date.new(2026, 1, 1))
+    schedule.funding_events.create!(occurs_on: Date.new(2026, 1, 1))
+    schedule.funding_events.create!(occurs_on: Date.new(2026, 1, 8))
+
+    events = schedule.materialize_events_through(end_date: Date.new(2026, 1, 22))
+
+    assert_equal [ Date.new(2026, 1, 15), Date.new(2026, 1, 22) ], events.map(&:occurs_on)
+  end
+
+  test 'materialize_events_through is idempotent' do
+    schedule = @user.funding_schedules.create!(name: 'Idem', cadence: 'weekly', start_date: Date.new(2026, 1, 1))
+
+    schedule.materialize_events_through(end_date: Date.new(2026, 1, 22))
+
+    assert_no_difference 'schedule.funding_events.count' do
+      schedule.materialize_events_through(end_date: Date.new(2026, 1, 22))
+    end
+  end
+
   test 'next_occurrences skips past dates and starts at first occurrence on or after after' do
     schedule = build(cadence: 'weekly', start_date: Date.new(2026, 1, 1))
 

--- a/test/models/funding_schedule_test.rb
+++ b/test/models/funding_schedule_test.rb
@@ -129,6 +129,21 @@ class FundingScheduleTest < ActiveSupport::TestCase
     end
   end
 
+  test 'occurrence_count_between returns the exact count even past 100 occurrences' do
+    schedule = @user.funding_schedules.create!(name: 'Weekly', cadence: 'weekly', start_date: Date.new(2026, 1, 1))
+
+    # 2 years of weekly = 105 paychecks. The old 100-cap would have undercounted this.
+    count = schedule.occurrence_count_between(after: Date.new(2026, 1, 1), through: Date.new(2027, 12, 31))
+
+    assert_equal 105, count
+  end
+
+  test 'occurrence_count_between returns 0 when through is before after' do
+    schedule = @user.funding_schedules.create!(name: 'W', cadence: 'weekly', start_date: Date.new(2026, 1, 1))
+
+    assert_equal 0, schedule.occurrence_count_between(after: Date.new(2026, 2, 1), through: Date.new(2026, 1, 1))
+  end
+
   test 'next_occurrences skips past dates and starts at first occurrence on or after after' do
     schedule = build(cadence: 'weekly', start_date: Date.new(2026, 1, 1))
 

--- a/test/services/allocation_engine_test.rb
+++ b/test/services/allocation_engine_test.rb
@@ -1,0 +1,111 @@
+require 'test_helper'
+
+class AllocationEngineTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:johndoe)
+    # Wipe fixtures so each test starts with a clean allocation state for this user.
+    @user.expenses.destroy_all
+    @user.funding_schedules.destroy_all
+
+    @schedule = @user.funding_schedules.create!(name: 'Paycheck', cadence: 'biweekly', start_date: Date.new(2026, 1, 1))
+  end
+
+  test 'propose_for creates one allocation per expense, all pending' do
+    expense = create_expense(name: 'Netflix', amount: 15.99, due_on: Date.new(2026, 1, 29)) # 3 paychecks: Jan 1, 15, 29
+    event = @schedule.funding_events.create!(occurs_on: Date.new(2026, 1, 1))
+
+    assert_difference 'Allocation.count', 1 do
+      AllocationEngine.propose_for(event)
+    end
+
+    allocation = event.allocations.find_by(expense: expense)
+    assert_in_delta 5.33, allocation.amount.to_f, 0.01 # 15.99 / 3
+    assert_nil allocation.funded_at
+    assert event.reload.processed_at.present?
+  end
+
+  test 'propose_for is idempotent' do
+    create_expense(name: 'Netflix', amount: 15.99, due_on: Date.new(2026, 1, 29))
+    event = @schedule.funding_events.create!(occurs_on: Date.new(2026, 1, 1))
+
+    AllocationEngine.propose_for(event)
+
+    assert_no_difference 'Allocation.count' do
+      AllocationEngine.propose_for(event)
+    end
+  end
+
+  test 'propose_for skips fully-funded expenses' do
+    expense = create_expense(name: 'Netflix', amount: 15.99, due_on: Date.new(2026, 1, 29))
+    earlier_event = @schedule.funding_events.create!(occurs_on: Date.new(2025, 12, 18))
+    Allocation.create!(funding_event: earlier_event, expense: expense, amount: 15.99, funded_at: Time.current)
+
+    new_event = @schedule.funding_events.create!(occurs_on: Date.new(2026, 1, 1))
+
+    assert_no_difference 'Allocation.count' do
+      AllocationEngine.propose_for(new_event)
+    end
+  end
+
+  test 'propose_for past-due expense allocates full remaining' do
+    expense = create_expense(name: 'Bill', amount: 100, due_on: Date.new(2025, 12, 1)) # past due
+    event = @schedule.funding_events.create!(occurs_on: Date.new(2026, 1, 1))
+
+    AllocationEngine.propose_for(event)
+
+    allocation = event.allocations.find_by(expense: expense)
+    assert_equal 100.00, allocation.amount.to_f
+  end
+
+  test 'fund_pending_for funds everything when balance covers' do
+    expense = create_expense(name: 'Netflix', amount: 15.99, due_on: Date.new(2026, 1, 29))
+    event = @schedule.funding_events.create!(occurs_on: Date.new(2026, 1, 1))
+    AllocationEngine.propose_for(event)
+
+    AllocationEngine.fund_pending_for(@user)
+
+    assert event.allocations.find_by(expense: expense).funded_at.present?
+  end
+
+  test 'fund_pending_for funds in due-date order when balance is partial' do
+    # Urgent allocation will be $30 (60 / 2 paychecks), Later will be $20 (80 / 4).
+    # Total available $30 covers urgent only.
+    bank_accounts(:chase_checking).update!(available_balance: 30)
+    bank_accounts(:chase_savings).update!(available_balance: 0)
+
+    urgent = create_expense(name: 'Urgent', amount: 60, due_on: Date.new(2026, 1, 15))
+    later  = create_expense(name: 'Later',  amount: 80, due_on: Date.new(2026, 2, 12))
+
+    event = @schedule.funding_events.create!(occurs_on: Date.new(2026, 1, 1))
+    AllocationEngine.propose_for(event)
+
+    AllocationEngine.fund_pending_for(@user)
+
+    urgent_alloc = event.allocations.find_by(expense: urgent)
+    later_alloc  = event.allocations.find_by(expense: later)
+    assert urgent_alloc.funded_at.present?, 'urgent expense should be funded first'
+    assert_nil later_alloc.funded_at, 'later expense should remain pending when balance runs out'
+  end
+
+  test 'fund_pending_for picks up previously-pending allocations on a later run' do
+    # Allocation will be ~$5.33; start with $4 total available so it doesn't fit.
+    @user.bank_accounts.update_all(available_balance: 2) # rubocop:disable Rails/SkipsModelValidations
+    expense = create_expense(name: 'Netflix', amount: 15.99, due_on: Date.new(2026, 1, 29))
+    event = @schedule.funding_events.create!(occurs_on: Date.new(2026, 1, 1))
+    AllocationEngine.propose_for(event)
+    AllocationEngine.fund_pending_for(@user)
+    assert_nil event.allocations.find_by(expense: expense).funded_at
+
+    @user.bank_accounts.update_all(available_balance: 100) # rubocop:disable Rails/SkipsModelValidations
+
+    AllocationEngine.fund_pending_for(@user)
+
+    assert event.allocations.find_by(expense: expense).reload.funded_at.present?
+  end
+
+  private
+
+  def create_expense(name:, amount:, due_on:)
+    @user.expenses.create!(name: name, amount: amount, cadence: 'monthly', due_on: due_on, funding_schedule: @schedule)
+  end
+end


### PR DESCRIPTION
## Summary

Phase 3a of the Simple-style Expenses feature. As each scheduled paycheck date arrives, the engine fills expense buckets so that by the due date the bucket equals the expense amount — Simple's look-ahead split (remaining ÷ paychecks-remaining-until-due).

**Critical constraint — virtual money must be backed by real money.** A funding event *proposes* allocations on its scheduled date, but each allocation only "funds" (sets `funded_at`) when the user's available bank balance can back the running total. Funding happens in **due-date order** — most urgent expenses are funded first. Anything left pending stays pending and retries hourly until the balance catches up.

## What's in this PR

- **New models**: `FundingEvent` (per schedule per occurrence) and `Allocation` (per funding event per expense, with `funded_at` lifecycle).
- **`AllocationEngine` service**:
  - `propose_for(event)` creates pending `Allocation` rows (one per expense on the schedule).
  - `fund_pending_for(user)` flips `funded_at` on pending allocations in due-date order, walking the user's bank `available_balance`.
- **`ProcessFundingEventsJob`** (hourly via `config/recurring.yml`): materialize new events → propose allocations → fund pending allocations across all users.
- **`Expense#bucket_balance`** counts only funded allocations. **`Expense#off_track?`** is true when any allocation is still pending.
- **Expense row UI** gains a daisyUI progress bar (funded / target) plus an "Off track" badge when pending allocations exist.

## What's out of scope (later PRs)

- Phase 3b — transaction-to-expense linking (bucket reset on transaction match + due-date advance).
- Phase 3c — safe-to-spend on `/transactions` (`available_balance − Σ(bucket_balance)`).
- Manual "process now" button + Today view of in-flight + off-track allocations.

## Test plan

- [ ] Deploy. `heroku run rails db:migrate` succeeds.
- [ ] In the Mission Control UI at `/jobs`, confirm the new `process_funding_events` recurring entry shows up.
- [ ] Create a biweekly funding schedule starting today and two monthly expenses ($15.99 and $100, both tied to it).
- [ ] Trigger `ProcessFundingEventsJob.perform_now`. `/expenses` shows progress bars for each expense at the correct % and no "Off track" badges.
- [ ] Drop `available_balance` on the linked bank so only the more-urgent expense's allocation fits. Move time forward to the next event, re-run the job. The urgent expense funds; the other shows the warning-tinted bar + "Off track" badge.
- [ ] Bring `available_balance` back up. Next hourly run flips the pending allocation to funded; badge disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)