### PR TITLE
Bump undici to ^7.28.0 to resolve security advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2231,9 +2231,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.26.0.tgz",
-      "integrity": "sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "tailwindcss": "^4.3.0"
   },
   "overrides": {
-    "undici": "^7.20.0"
+    "undici": "^7.28.0"
   }
 }


### PR DESCRIPTION
## Summary
Bumps the `undici` override from `^7.20.0` to `^7.28.0`, which held the transitive dependency (via `@codecov/bundle-analyzer`) at 7.26.0. `7.28.0` is the first release that patches all 6 open Dependabot alerts.

## Alerts resolved
| Sev | Advisory |
|-----|----------|
| high | TLS certificate validation bypass via dropped requestTls in SOCKS5 ProxyAgent |
| high | Cross-origin request routing via SOCKS5 proxy pool reuse |
| medium | HTTP header injection via Set-Cookie percent-decoding |
| medium | Cross-user information disclosure via shared cache whitespace bypass |
| low | HTTP response queue poisoning via keep-alive socket reuse |
| low | Set-Cookie SameSite attribute downgrade via permissive substring matching |

## Verification
- `npm audit` → 0 vulnerabilities
- `npm run build` → succeeds
- `undici` now resolves to 7.28.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)