### PR TITLE
Open edit drawer on row tap; move delete into the drawer

### DIFF
--- a/app/views/components/_confirm_delete_modal.html.erb
+++ b/app/views/components/_confirm_delete_modal.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (toggle_id:, title:, message:, delete_path:, loading_text: 'Deleting...') %>
+<%# locals: (toggle_id:, title:, message:, delete_path:, loading_text: 'Deleting...', form_data: nil) %>
 
 <input type="checkbox" id="<%= toggle_id %>" class="modal-toggle" />
 <div class="modal modal-middle">
@@ -7,9 +7,19 @@
     <p class="py-4"><%= message %></p>
     <div class="modal-action">
       <label for="<%= toggle_id %>" class="btn">Cancel</label>
-      <%= link_to 'Delete', delete_path,
-            data: { turbo_method: :delete, controller: 'loading-button', loading_button_text_value: loading_text },
-            class: 'btn btn-error' %>
+      <% if form_data %>
+        <%# button_to renders an inline form, so turbo:submit-end fires on it —
+            letting callers (e.g. the expense drawer) hook the form to close. %>
+        <%= button_to 'Delete', delete_path,
+              method: :delete,
+              class: 'btn btn-error',
+              data: { controller: 'loading-button', loading_button_text_value: loading_text },
+              form: { data: form_data } %>
+      <% else %>
+        <%= link_to 'Delete', delete_path,
+              data: { turbo_method: :delete, controller: 'loading-button', loading_button_text_value: loading_text },
+              class: 'btn btn-error' %>
+      <% end %>
     </div>
   </div>
   <label class="modal-backdrop" for="<%= toggle_id %>">Close</label>

--- a/app/views/expenses/_expense.html.erb
+++ b/app/views/expenses/_expense.html.erb
@@ -1,8 +1,11 @@
 <%# locals: (expense:) %>
 
-<div class="relative">
-  <div class="flex items-center px-4 py-3 gap-3 bg-base-200 rounded-xl pr-24">
-    <div class="min-w-0 flex-1">
+<%= link_to edit_expense_path(expense),
+      class: "block bg-base-200 rounded-xl transition-colors hover:bg-base-300 focus-visible:outline-2 focus-visible:outline-primary",
+      "aria-label": "Edit #{expense.name}",
+      data: { turbo_frame: "drawer_content", action: "click->drawer#open" } do %>
+  <div class="px-4 py-3">
+    <div class="min-w-0">
       <div class="flex items-baseline gap-2 min-w-0">
         <p class="font-medium truncate"><%= expense.name %></p>
         <p class="font-semibold tabular-nums shrink-0"><%= number_to_currency(expense.amount) %></p>
@@ -32,27 +35,4 @@
       </div>
     </div>
   </div>
-
-  <%= link_to edit_expense_path(expense),
-        class: "btn btn-ghost btn-sm text-primary absolute right-12 top-1/2 -translate-y-1/2",
-        "aria-label": "Edit #{expense.name}",
-        data: { turbo_frame: "drawer_content", action: "click->drawer#open" } do %>
-    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
-    </svg>
-  <% end %>
-
-  <label for="delete_expense_<%= expense.id %>"
-         class="btn btn-ghost btn-sm text-error absolute right-2 top-1/2 -translate-y-1/2 cursor-pointer"
-         aria-label="Delete <%= expense.name %>">
-    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-    </svg>
-  </label>
-
-  <%= render 'components/confirm_delete_modal',
-        toggle_id: "delete_expense_#{expense.id}",
-        title: 'Delete expense',
-        message: "Are you sure you want to delete \"#{expense.name}\"?",
-        delete_path: expense_path(expense) %>
-</div>
+<% end %>

--- a/app/views/expenses/_form.html.erb
+++ b/app/views/expenses/_form.html.erb
@@ -91,11 +91,30 @@
       </fieldset>
     </div>
 
-    <div class="border-t border-base-300 p-5 shrink-0">
+    <div class="border-t border-base-300 p-5 shrink-0 space-y-3">
       <div class="flex gap-2">
         <%= f.submit class: "btn btn-primary flex-1", data: { controller: "loading-button" } %>
         <button type="button" class="btn btn-ghost flex-1" data-action="click->drawer#close">Cancel</button>
       </div>
+      <% if expense.persisted? %>
+        <label for="delete_expense_<%= expense.id %>" class="btn btn-ghost btn-block text-error">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+          </svg>
+          Delete expense
+        </label>
+      <% end %>
     </div>
+  <% end %>
+
+  <% if expense.persisted? %>
+    <%# Rendered outside the form above so the delete request isn't a nested form,
+        and so the modal's button_to can close the drawer once the delete succeeds. %>
+    <%= render 'components/confirm_delete_modal',
+          toggle_id: "delete_expense_#{expense.id}",
+          title: 'Delete expense',
+          message: "Are you sure you want to delete \"#{expense.name}\"?",
+          delete_path: expense_path(expense),
+          form_data: { action: "turbo:submit-end->drawer#closeOnSuccess" } %>
   <% end %>
 </div>

--- a/app/views/funding_schedules/_form.html.erb
+++ b/app/views/funding_schedules/_form.html.erb
@@ -72,11 +72,30 @@
       </fieldset>
     </div>
 
-    <div class="border-t border-base-300 p-5 shrink-0">
+    <div class="border-t border-base-300 p-5 shrink-0 space-y-3">
       <div class="flex gap-2">
         <%= f.submit class: "btn btn-primary flex-1", data: { controller: "loading-button" } %>
         <button type="button" class="btn btn-ghost flex-1" data-action="click->drawer#close">Cancel</button>
       </div>
+      <% if funding_schedule.persisted? %>
+        <label for="delete_funding_schedule_<%= funding_schedule.id %>" class="btn btn-ghost btn-block text-error">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+          </svg>
+          Delete funding schedule
+        </label>
+      <% end %>
     </div>
+  <% end %>
+
+  <% if funding_schedule.persisted? %>
+    <%# Rendered outside the form above so the delete request isn't a nested form,
+        and so the modal's button_to can close the drawer once the delete succeeds. %>
+    <%= render 'components/confirm_delete_modal',
+          toggle_id: "delete_funding_schedule_#{funding_schedule.id}",
+          title: 'Delete funding schedule',
+          message: "Are you sure you want to delete \"#{funding_schedule.name}\"?",
+          delete_path: funding_schedule_path(funding_schedule),
+          form_data: { action: "turbo:submit-end->drawer#closeOnSuccess" } %>
   <% end %>
 </div>

--- a/app/views/settings/_funding_schedules.html.erb
+++ b/app/views/settings/_funding_schedules.html.erb
@@ -18,38 +18,18 @@
 
       <div class="space-y-2 mt-2">
         <% @funding_schedules.each do |schedule| %>
-          <div class="relative">
-            <div class="flex items-center px-4 py-3 gap-3 bg-base-200 rounded-xl pr-24">
-              <div class="min-w-0 flex-1">
-                <p class="font-medium truncate"><%= schedule.name %></p>
-                <p class="text-sm text-base-content/60 truncate">
-                  <%= schedule.cadence.titleize %> · Next:
-                  <%= schedule.next_occurrences(count: 2).map { |d| d.strftime("%b %-d") }.join(", ") %>
-                </p>
-              </div>
+          <%= link_to edit_funding_schedule_path(schedule),
+                class: "block bg-base-200 rounded-xl transition-colors hover:bg-base-300 focus-visible:outline-2 focus-visible:outline-primary",
+                "aria-label": "Edit #{schedule.name}",
+                data: { turbo_frame: "drawer_content", action: "click->drawer#open" } do %>
+            <div class="px-4 py-3">
+              <p class="font-medium truncate"><%= schedule.name %></p>
+              <p class="text-sm text-base-content/60 truncate">
+                <%= schedule.cadence.titleize %> · Next:
+                <%= schedule.next_occurrences(count: 2).map { |d| d.strftime("%b %-d") }.join(", ") %>
+              </p>
             </div>
-            <%= link_to edit_funding_schedule_path(schedule),
-                  class: "btn btn-ghost btn-sm text-primary absolute right-12 top-1/2 -translate-y-1/2",
-                  "aria-label": "Edit #{schedule.name}",
-                  data: { turbo_frame: "drawer_content", action: "click->drawer#open" } do %>
-              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
-              </svg>
-            <% end %>
-            <label for="delete_funding_schedule_<%= schedule.id %>"
-                   class="btn btn-ghost btn-sm text-error absolute right-2 top-1/2 -translate-y-1/2 cursor-pointer"
-                   aria-label="Delete <%= schedule.name %>">
-              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-            </label>
-
-            <%= render 'components/confirm_delete_modal',
-                  toggle_id: "delete_funding_schedule_#{schedule.id}",
-                  title: 'Delete funding schedule',
-                  message: "Are you sure you want to delete \"#{schedule.name}\"?",
-                  delete_path: funding_schedule_path(schedule) %>
-          </div>
+          <% end %>
         <% end %>
         <p class="text-sm text-base-content/40 text-center py-6 <%= 'hidden' if @funding_schedules.any? %>">
           No funding schedules yet.


### PR DESCRIPTION
## Summary
Makes the Expenses list and the Settings → Funding schedules list use the same tap-anywhere interaction the Transactions list already uses:

- The entire row is now a link that opens the edit drawer (hover background + focus outline, no chevron — matching transactions).
- The per-row edit/delete icon buttons are gone.
- Deletion now lives **inside the drawer** as a "Delete" button that opens the existing styled confirm modal, and the drawer closes itself once the delete succeeds.

## How the in-drawer delete closes the drawer
Turbo turns a `data-turbo-method` link into a form it appends to `<body>`, so `turbo:submit-end` never bubbles through the link — a `drawer#closeOnSuccess` action on it would never fire. To fix this, the shared `confirm_delete_modal` component gains an optional `form_data` local: when present, the delete renders as a `button_to` (an inline form) so the event fires on a real form element we can hook. Callers that don't pass `form_data` (Linked account) keep their original `link_to` behavior unchanged.

## Files
- `expenses/_expense.html.erb` — row is a full-row drawer link; removed icons
- `expenses/_form.html.erb` — Delete button + confirm modal in the drawer
- `settings/_funding_schedules.html.erb` — row is a full-row drawer link; removed icons
- `funding_schedules/_form.html.erb` — Delete button + confirm modal in the drawer
- `components/_confirm_delete_modal.html.erb` — optional `form_data` → `button_to` branch

## Notes
- A funding schedule destroy can still fail server-side (dependent expenses); the controller redirects to settings with an alert as before — Turbo follows it, so the drawer closes and the alert shows.

## Testing
- Full suite green: `385 runs, 1074 assertions, 0 failures`. Covers the `index`/`edit` renders for both resources and the other shared-modal caller.
- No system tests exist for these pages, so the click-through (row → drawer, delete → confirm → drawer closes) was verified via template rendering + established Stimulus patterns rather than an end-to-end browser run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)