### PR TITLE
Add Free-to-Spend to the transactions header

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -5,8 +5,10 @@ class TransactionsController < ApplicationController
       Current.user.transactions.includes(:expense).order(Arel.sql('date DESC NULLS LAST, created_at DESC')),
       limit: 25
     )
+    # Free-to-Spend (available balance minus funded buckets) is computed in
+    # the transactions/_free_to_spend partial so the link/unlink streams can
+    # re-render it.
     @has_bank = Current.user.banks.exists?
-    @available_balance = Current.user.bank_accounts.sum(:available_balance) if @has_bank
   end
 
   def show

--- a/app/views/transaction_expenses/create.turbo_stream.erb
+++ b/app/views/transaction_expenses/create.turbo_stream.erb
@@ -9,3 +9,9 @@
 <%= turbo_stream.replace dom_id(@transaction) do %>
   <%= render @transaction, transaction_name_overrides: @transaction_name_overrides %>
 <% end %>
+
+<%# Linking spends the expense's funded allocations, shrinking "in buckets"
+    and raising Free-to-Spend — keep the index header in sync. %>
+<%= turbo_stream.replace 'free_to_spend' do %>
+  <%= render 'transactions/free_to_spend' %>
+<% end %>

--- a/app/views/transaction_expenses/destroy.turbo_stream.erb
+++ b/app/views/transaction_expenses/destroy.turbo_stream.erb
@@ -9,3 +9,9 @@
 <%= turbo_stream.replace dom_id(@transaction) do %>
   <%= render @transaction, transaction_name_overrides: @transaction_name_overrides %>
 <% end %>
+
+<%# Unlinking restores the allocations to their buckets, lowering
+    Free-to-Spend again — keep the index header in sync. %>
+<%= turbo_stream.replace 'free_to_spend' do %>
+  <%= render 'transactions/free_to_spend' %>
+<% end %>

--- a/app/views/transactions/_free_to_spend.html.erb
+++ b/app/views/transactions/_free_to_spend.html.erb
@@ -1,6 +1,7 @@
 <%# Free-to-Spend summary. Self-contained (computes from Current.user) so the
-    link/unlink turbo streams can re-render it when buckets change. The
-    aggregate mirrors expenses/_list.html.erb — one query, no N+1. %>
+    link/unlink turbo streams can re-render it when buckets change. The bucket
+    total is a single aggregate query (mirrors expenses/_list.html.erb),
+    avoiding the per-expense N+1 of summing bucket_balance one row at a time. %>
 <div id="free_to_spend" class="text-right">
   <% if Current.user.banks.exists? %>
     <%

--- a/app/views/transactions/_free_to_spend.html.erb
+++ b/app/views/transactions/_free_to_spend.html.erb
@@ -1,0 +1,33 @@
+<%# Free-to-Spend summary. Self-contained (computes from Current.user) so the
+    link/unlink turbo streams can re-render it when buckets change. The
+    aggregate mirrors expenses/_list.html.erb — one query, no N+1. %>
+<div id="free_to_spend" class="text-right">
+  <% if Current.user.banks.exists? %>
+    <%
+      available = Current.user.bank_accounts.sum(:available_balance)
+      allocated = Current.user.expenses
+                          .joins(:allocations)
+                          .where.not(allocations: { funded_at: nil })
+                          .where('allocations.amount > allocations.spent_amount')
+                          .sum(Arel.sql('allocations.amount - allocations.spent_amount'))
+      free = available - allocated
+    %>
+    <details class="group">
+      <summary class="list-none cursor-pointer [&::-webkit-details-marker]:hidden">
+        <div class="text-xs text-base-content/60">Free-to-Spend</div>
+        <div class="flex items-center justify-end gap-1">
+          <span class="text-2xl font-bold tabular-nums leading-tight <%= 'text-error' if free.negative? %>">
+            <%= number_to_currency(free) %>
+          </span>
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 text-base-content/40 transition-transform group-open:rotate-180" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+          </svg>
+        </div>
+      </summary>
+      <div class="text-xs text-base-content/60 mt-1 space-y-0.5">
+        <div><%= number_to_currency(available) %> available</div>
+        <div><%= number_to_currency(allocated) %> in buckets</div>
+      </div>
+    </details>
+  <% end %>
+</div>

--- a/app/views/transactions/index.html.erb
+++ b/app/views/transactions/index.html.erb
@@ -1,14 +1,9 @@
 <% content_for :title, "Transactions" %>
 
 <div class="flex flex-col items-center pb-10">
-  <div class="w-full max-w-240 mt-10 px-4 flex items-baseline justify-between gap-3">
+  <div class="w-full max-w-240 mt-10 px-4 flex items-center justify-between gap-3">
     <h2 class="text-2xl font-bold">Transactions</h2>
-    <% if @has_bank %>
-      <div class="text-sm text-right">
-        <span class="text-base-content/60">Available Balance:</span>
-        <span class="font-semibold tabular-nums ml-1"><%= number_to_currency(@available_balance) %></span>
-      </div>
-    <% end %>
+    <%= render 'free_to_spend' %>
   </div>
 
   <% if @transactions.any? %>

--- a/test/controllers/transaction_expenses_controller_test.rb
+++ b/test/controllers/transaction_expenses_controller_test.rb
@@ -102,6 +102,20 @@ class TransactionExpensesControllerTest < ActionDispatch::IntegrationTest
     assert_nil @transaction.reload.expense
   end
 
+  test 'create re-renders the free-to-spend header with the updated total' do
+    sign_in_as(@user)
+    fully_fund(@netflix)
+
+    post transaction_expenses_url,
+         params: { transaction_id: @transaction.id, expense_id: @netflix.id },
+         headers: { Accept: 'text/vnd.turbo-stream.html' }
+
+    assert_response :success
+    assert_match(/turbo-stream action="replace" target="free_to_spend"/, response.body)
+    # Netflix's $15.99 bucket is now spent → $0 in buckets, full $6,000 free.
+    assert_match(/\$0\.00 in buckets/, response.body)
+  end
+
   test 'destroy responds with turbo_stream replacing drawer_content' do
     sign_in_as(@user)
     fully_fund(@netflix)
@@ -111,6 +125,19 @@ class TransactionExpensesControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_match(/turbo-stream action="replace" target="drawer_content"/, response.body)
+  end
+
+  test 'destroy re-renders the free-to-spend header with the restored total' do
+    sign_in_as(@user)
+    fully_fund(@netflix)
+    ExpenseLinker.link(transaction: @transaction, expense: @netflix)
+
+    delete transaction_expense_url(@transaction), headers: { Accept: 'text/vnd.turbo-stream.html' }
+
+    assert_response :success
+    assert_match(/turbo-stream action="replace" target="free_to_spend"/, response.body)
+    # Unlinking restores Netflix's $15.99 to its bucket.
+    assert_match(/\$15\.99 in buckets/, response.body)
   end
 
   private

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -79,23 +79,39 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     assert_select 'a', text: /Prev/
   end
 
-  test 'index shows aggregated available balance when a bank is linked' do
+  test 'index shows free-to-spend as available balance minus funded buckets' do
     sign_in_as(users(:johndoe))
 
     get transactions_url
 
+    # chase checking ($1000) + savings ($5000) = $6000 available;
+    # only netflix_first ($8.00) is funded and unspent → $5,992.00 free.
     assert_response :success
-    assert_select 'span', text: 'Available Balance:'
-    assert_select 'span', text: '$6,000.00'
+    assert_select 'div', text: 'Free-to-Spend'
+    assert_select 'span', text: '$5,992.00'
+    assert_select 'div', text: '$6,000.00 available'
+    assert_select 'div', text: '$8.00 in buckets'
   end
 
-  test 'index does not render an available balance when no bank is linked' do
+  test 'index renders negative safe-to-spend with error styling' do
+    bank_accounts(:chase_checking).update!(available_balance: 0)
+    bank_accounts(:chase_savings).update!(available_balance: 0)
+    sign_in_as(users(:johndoe))
+
+    get transactions_url
+
+    # $0 available, $8.00 reserved in buckets → -$8.00 free to spend.
+    assert_response :success
+    assert_select 'span.text-error', text: '-$8.00'
+  end
+
+  test 'index does not render free-to-spend when no bank is linked' do
     sign_in_as(users(:admin))
 
     get transactions_url
 
     assert_response :success
-    assert_select 'span', text: 'Available Balance:', count: 0
+    assert_select 'div', text: 'Free-to-Spend', count: 0
   end
 
   test 'show requires authentication' do

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -93,7 +93,7 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     assert_select 'div', text: '$8.00 in buckets'
   end
 
-  test 'index renders negative safe-to-spend with error styling' do
+  test 'index renders negative free-to-spend with error styling' do
     bank_accounts(:chase_checking).update!(available_balance: 0)
     bank_accounts(:chase_savings).update!(available_balance: 0)
     sign_in_as(users(:johndoe))


### PR DESCRIPTION
## Summary
Phase 3c of the Simple-style Expenses rollout — the final piece. Surfaces **Free-to-Spend** at the top of `/transactions`:

```
available_balance − Σ(expense funded bucket balances)
```

i.e. money left after every funded expense bucket is accounted for. Computed in a single aggregate query (no N+1), mirroring the aggregate in `expenses/_list.html.erb`.

## Behavior
- The figure is the headline; a tap-to-expand `<details>` disclosure reveals the breakdown (`$X available` / `$Y in buckets`), with the caret flipping on open.
- Negative totals (buckets exceed available balance) render in `text-error`.
- Only shown when a bank is linked.

## Stays in sync with linking
The figure lives in a self-contained `transactions/_free_to_spend` partial wrapped in `#free_to_spend`. Linking a transaction to an expense spends that expense's funded allocations (lowering "in buckets", raising Free-to-Spend); unlinking restores them. Both the link and unlink turbo streams now `replace` `#free_to_spend`, fixing a bug where the header showed a stale total after linking.

## Naming
Called **Free-to-Spend** rather than Simple's "Safe-to-Spend" — that exact phrase was a registered (EU) trademark Simple actively enforced (cease-and-desist to Monzo in 2015). Simple is defunct, so the real-world risk is low, but the rename costs nothing and avoids the question.

## Files
- `transactions/_free_to_spend.html.erb` — new self-contained partial
- `transactions/index.html.erb` — renders the partial in the header
- `transactions_controller.rb` — drops the now-partial-computed ivars (keeps `@has_bank`)
- `transaction_expenses/{create,destroy}.turbo_stream.erb` — re-render the header on link/unlink

## Testing
- Full suite green: `388 runs, 1091 assertions, 0 failures`; rubocop clean.
- Added: link response shows `$0.00 in buckets`; unlink restores `$15.99 in buckets`; positive/negative figure rendering; omitted with no bank linked.
- No system tests exist for `/transactions`, so the tap-to-expand interaction is covered by template rendering + native `<details>` semantics, not an end-to-end browser run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)