### PR TITLE
Add manual allocation to expenses and goals

### DIFF
--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -39,15 +39,22 @@ class ExpensesController < ApplicationController
   end
 
   def update
-    if @expense.update(expense_params)
-      load_expenses_for_index
-      respond_to do |format|
-        format.turbo_stream
-        format.html { redirect_to expenses_path, notice: 'Expense updated' }
-      end
-    else
+    unless @expense.update(expense_params)
       @funding_schedules = Current.user.funding_schedules.order(:name)
-      render :edit, status: :unprocessable_content, formats: [ :html ]
+      return render :edit, status: :unprocessable_content, formats: [ :html ]
+    end
+
+    allocation = apply_allocated_amount(@expense)
+    if allocation && !allocation.ok?
+      @allocation_error = allocation.error
+      @funding_schedules = Current.user.funding_schedules.order(:name)
+      return render :edit, status: :unprocessable_content, formats: [ :html ]
+    end
+
+    load_expenses_for_index
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to expenses_path, notice: 'Expense updated' }
     end
   end
 
@@ -73,5 +80,15 @@ class ExpensesController < ApplicationController
 
   def expense_params
     params.expect(expense: [ :name, :amount, :cadence, :due_on, :funding_schedule_id ])
+  end
+
+  # The drawer's "Allocated" field (shown only when a bank is linked) sets the
+  # bucket balance to the typed total. Blank means "leave it alone". Returns the
+  # ManualAllocator result, or nil when there's nothing to apply.
+  def apply_allocated_amount(expense)
+    amount = params.fetch(:allocated_amount, nil)
+    return if amount.blank?
+
+    ManualAllocator.set_balance(item: expense, amount: amount.to_d)
   end
 end

--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -39,14 +39,21 @@ class ExpensesController < ApplicationController
   end
 
   def update
-    unless @expense.update(expense_params)
-      @funding_schedules = Current.user.funding_schedules.order(:name)
-      return render :edit, status: :unprocessable_content, formats: [ :html ]
+    # The drawer's Update saves the expense and its allocated balance together,
+    # so apply both atomically — an allocation failure (e.g. over Free-to-Spend)
+    # rolls back the record changes too.
+    allocation = nil
+    updated = false
+    ActiveRecord::Base.transaction do
+      updated = @expense.update(expense_params)
+      raise ActiveRecord::Rollback unless updated
+
+      allocation = apply_allocated_amount(@expense)
+      raise ActiveRecord::Rollback if allocation && !allocation.ok?
     end
 
-    allocation = apply_allocated_amount(@expense)
-    if allocation && !allocation.ok?
-      @allocation_error = allocation.error
+    if !updated || allocation&.error
+      @allocation_error = allocation&.error
       @funding_schedules = Current.user.funding_schedules.order(:name)
       return render :edit, status: :unprocessable_content, formats: [ :html ]
     end

--- a/app/controllers/goals_controller.rb
+++ b/app/controllers/goals_controller.rb
@@ -39,15 +39,22 @@ class GoalsController < ApplicationController
   end
 
   def update
-    if @goal.update(goal_params)
-      load_goals_for_index
-      respond_to do |format|
-        format.turbo_stream
-        format.html { redirect_to goals_path, notice: 'Goal updated' }
-      end
-    else
+    unless @goal.update(goal_params)
       @funding_schedules = Current.user.funding_schedules.order(:name)
-      render :edit, status: :unprocessable_content, formats: [ :html ]
+      return render :edit, status: :unprocessable_content, formats: [ :html ]
+    end
+
+    allocation = apply_allocated_amount(@goal)
+    if allocation && !allocation.ok?
+      @allocation_error = allocation.error
+      @funding_schedules = Current.user.funding_schedules.order(:name)
+      return render :edit, status: :unprocessable_content, formats: [ :html ]
+    end
+
+    load_goals_for_index
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to goals_path, notice: 'Goal updated' }
     end
   end
 
@@ -73,5 +80,15 @@ class GoalsController < ApplicationController
 
   def goal_params
     params.expect(goal: [ :name, :amount, :cadence, :due_on, :funding_schedule_id ])
+  end
+
+  # The drawer's "Allocated" field (shown only when a bank is linked) sets the
+  # bucket balance to the typed total. Blank means "leave it alone". Returns the
+  # ManualAllocator result, or nil when there's nothing to apply.
+  def apply_allocated_amount(goal)
+    amount = params.fetch(:allocated_amount, nil)
+    return if amount.blank?
+
+    ManualAllocator.set_balance(item: goal, amount: amount.to_d)
   end
 end

--- a/app/controllers/goals_controller.rb
+++ b/app/controllers/goals_controller.rb
@@ -39,14 +39,21 @@ class GoalsController < ApplicationController
   end
 
   def update
-    unless @goal.update(goal_params)
-      @funding_schedules = Current.user.funding_schedules.order(:name)
-      return render :edit, status: :unprocessable_content, formats: [ :html ]
+    # The drawer's Update saves the goal and its allocated balance together, so
+    # apply both atomically — an allocation failure (e.g. over Free-to-Spend)
+    # rolls back the record changes too.
+    allocation = nil
+    updated = false
+    ActiveRecord::Base.transaction do
+      updated = @goal.update(goal_params)
+      raise ActiveRecord::Rollback unless updated
+
+      allocation = apply_allocated_amount(@goal)
+      raise ActiveRecord::Rollback if allocation && !allocation.ok?
     end
 
-    allocation = apply_allocated_amount(@goal)
-    if allocation && !allocation.ok?
-      @allocation_error = allocation.error
+    if !updated || allocation&.error
+      @allocation_error = allocation&.error
       @funding_schedules = Current.user.funding_schedules.order(:name)
       return render :edit, status: :unprocessable_content, formats: [ :html ]
     end

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -1,9 +1,16 @@
 class Allocation < ApplicationRecord
   has_paper_trail
-  belongs_to :funding_event
+  # Optional: a manual allocation (user funded a bucket directly) has no
+  # funding_event. Auto allocations from the engine always set one.
+  belongs_to :funding_event, optional: true
   belongs_to :expense, optional: true
   belongs_to :goal, optional: true
   belongs_to :spent_by_transaction, class_name: 'Transaction', optional: true
+
+  # Manual allocations carry no funding_event. One per bucket, enforced by the
+  # uniqueness validations below (scope: :funding_event_id, IS NULL here) and a
+  # matching partial unique index.
+  scope :manual, -> { where(funding_event_id: nil) }
 
   validates :amount, presence: true, numericality: { greater_than: 0 }
   validates :spent_amount, presence: true, numericality: { greater_than_or_equal_to: 0 }

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -51,18 +51,20 @@ class Expense < ApplicationRecord
     bucket_balance >= amount
   end
 
-  # Steady-state per-paycheck contribution: amount / paychecks-until-next-due.
-  # Display-only — does NOT match what the engine proposes when a partial
-  # residual is sitting around (the engine subtracts that residual first).
-  # This is the "ongoing rate" answer to "how much of each paycheck does
-  # this expense take?"
+  # Per-paycheck contribution still needed: remaining-to-fund /
+  # paychecks-until-next-due. Display-only. Money already in the bucket lowers
+  # the remaining, so funding the expense (by paycheck or by hand) shrinks this
+  # rate; a fully-funded bucket needs $0/paycheck.
   def per_paycheck_amount(as_of: Date.current)
     next_due = next_due_on(after: as_of)
     return amount unless next_due && funding_schedule
 
+    remaining = amount - bucket_balance
+    return 0 if remaining <= 0
+
     paychecks = funding_schedule.occurrence_count_between(after: as_of, through: next_due)
     paychecks = 1 if paychecks.zero?
-    (amount / paychecks).round(2)
+    (remaining / paychecks).round(2)
   end
 
   # Roll due_on forward / backward by one cadence cycle. `bump_due_forward!`

--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -38,13 +38,20 @@ class Goal < ApplicationRecord
     bucket_balance >= amount
   end
 
+  # Per-paycheck contribution still needed: remaining-to-fund /
+  # paychecks-until-next-due. Display-only. Money already in the bucket lowers
+  # the remaining, so funding the goal (by paycheck or by hand) shrinks this
+  # rate; a fully-funded bucket needs $0/paycheck.
   def per_paycheck_amount(as_of: Date.current)
     next_due = next_due_on(after: as_of)
     return amount unless next_due && funding_schedule
 
+    remaining = amount - bucket_balance
+    return 0 if remaining <= 0
+
     paychecks = funding_schedule.occurrence_count_between(after: as_of, through: next_due)
     paychecks = 1 if paychecks.zero?
-    (amount / paychecks).round(2)
+    (remaining / paychecks).round(2)
   end
 
   def bump_due_forward!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,32 @@ class User < ApplicationRecord
 
   normalizes :email_address, with: ->(e) { e.strip.downcase }
 
+  # Money the bank says is spendable right now.
+  def available_balance
+    bank_accounts.sum(:available_balance)
+  end
+
+  # Money sitting in expense + goal buckets: the unspent remainder of every
+  # funded allocation across both. Single aggregate query per type (mirrors the
+  # expenses/goals list headers) so it stays cheap on the index pages.
+  def allocated_in_buckets
+    expense_allocated = expenses.joins(:allocations)
+                                .where.not(allocations: { funded_at: nil })
+                                .where('allocations.amount > allocations.spent_amount')
+                                .sum(Arel.sql('allocations.amount - allocations.spent_amount'))
+    goal_allocated = goals.joins(:allocations)
+                          .where.not(allocations: { funded_at: nil })
+                          .where('allocations.amount > allocations.spent_amount')
+                          .sum(Arel.sql('allocations.amount - allocations.spent_amount'))
+    expense_allocated + goal_allocated
+  end
+
+  # What's left to spend freely after buckets are funded. Manual allocations
+  # draw against this; ManualAllocator won't let an add push it negative.
+  def free_to_spend
+    available_balance - allocated_in_buckets
+  end
+
   private
 
   def email_on_allowlist

--- a/app/services/manual_allocator.rb
+++ b/app/services/manual_allocator.rb
@@ -1,0 +1,93 @@
+# Sets an expense/goal bucket's allocated balance to a target the user typed,
+# adding from or returning to Free-to-Spend by the difference. The allocated
+# balance is bucket_balance — the unspent remainder of every funded allocation,
+# whether the paycheck engine proposed it or the user added it by hand.
+#
+# Increases go onto a single manual allocation row (no funding_event, funded_at
+# set), which the engine subtracts from future paycheck proposals (see
+# AllocationEngine.compute_proposed_amount). Decreases draw down funded money —
+# the manual row first, then auto allocations newest-first — never below what a
+# linked transaction already spent.
+#
+# Serialized per-user with a row lock (matching AllocationEngine.fund_pending_for
+# and ExpenseLinker) so a concurrent fund/allocate can't read a stale
+# Free-to-Spend baseline. Per-row save!/update!/destroy! keeps callbacks +
+# PaperTrail intact.
+class ManualAllocator
+  Result = Struct.new(:ok, :error) do
+    def ok? = ok
+  end
+
+  def self.set_balance(item:, amount:)
+    new(item).set_balance(amount)
+  end
+
+  def initialize(item)
+    @item = item
+    @user = item.user
+  end
+
+  # rubocop:disable Naming/AccessorMethodName -- a command (set the bucket to a
+  # target), not an attribute writer.
+  def set_balance(amount)
+    target = round(amount)
+    return failure('Enter an amount of zero or more.') if target.negative?
+
+    @user.with_lock do
+      delta = target - @item.bucket_balance
+      if delta.positive?
+        return failure("That's more than your Free-to-Spend.") if delta > @user.free_to_spend
+
+        add(delta)
+      elsif delta.negative?
+        remove(-delta)
+      end
+    end
+
+    success
+  end
+  # rubocop:enable Naming/AccessorMethodName
+
+  private
+
+  def add(amount)
+    row = @item.allocations.manual.first_or_initialize
+    row.funded_at ||= Time.current
+    row.amount = (row.amount || 0) + amount
+    row.save!
+  end
+
+  def remove(amount)
+    remaining = amount
+    drawable_allocations.each do |allocation|
+      break if remaining <= 0
+
+      available = allocation.amount - allocation.spent_amount
+      take = [ available, remaining ].min
+      new_amount = allocation.amount - take
+
+      if new_amount <= allocation.spent_amount && allocation.spent_amount.zero?
+        allocation.destroy!
+      else
+        allocation.update!(amount: [ new_amount, allocation.spent_amount ].max)
+      end
+      remaining -= take
+    end
+  end
+
+  # Funded, unspent allocations to draw down, most-discretionary first: the
+  # user's own manual row before any scheduled paycheck money, then auto
+  # allocations newest-first (pull back the most recent funding first).
+  def drawable_allocations
+    @item.allocations.where.not(funded_at: nil)
+         .where('amount > spent_amount')
+         .to_a
+         .sort_by { |a| [ a.funding_event_id.nil? ? 0 : 1, -a.created_at.to_f ] }
+  end
+
+  def round(amount) = amount.to_d.round(2)
+
+  def success = Result.new(true, nil)
+
+  def failure(message) = Result.new(false, message)
+end

--- a/app/services/manual_allocator.rb
+++ b/app/services/manual_allocator.rb
@@ -86,10 +86,13 @@ class ManualAllocator
   # user's own manual row before any scheduled paycheck money, then auto
   # allocations newest-first (pull back the most recent funding first).
   def drawable_allocations
+    # Manual row first (funding_event_id IS NULL sorts ahead of NOT NULL), then
+    # auto allocations newest-first. Ordered in SQL, then materialized so we can
+    # mutate rows while iterating.
     @item.allocations.where.not(funded_at: nil)
          .where('amount > spent_amount')
+         .order(Arel.sql('funding_event_id IS NOT NULL, created_at DESC'))
          .to_a
-         .sort_by { |a| [ a.funding_event_id.nil? ? 0 : 1, -a.created_at.to_f ] }
   end
 
   def round(amount) = amount.to_d.round(2)

--- a/app/services/manual_allocator.rb
+++ b/app/services/manual_allocator.rb
@@ -9,10 +9,12 @@
 # the manual row first, then auto allocations newest-first — never below what a
 # linked transaction already spent.
 #
-# Serialized per-user with a row lock (matching AllocationEngine.fund_pending_for
-# and ExpenseLinker) so a concurrent fund/allocate can't read a stale
-# Free-to-Spend baseline. Per-row save!/update!/destroy! keeps callbacks +
-# PaperTrail intact.
+# Serialized with two nested row locks: the user row (matching
+# AllocationEngine.fund_pending_for) so the Free-to-Spend baseline can't shift
+# mid-calc, then the bucket row (matching ExpenseLinker/GoalLinker, which set
+# spent_amount under that same lock) so a concurrent link can't slip in between
+# our read and write and leave an allocation with amount < spent_amount.
+# Per-row save!/update!/destroy! keeps callbacks + PaperTrail intact.
 class ManualAllocator
   Result = Struct.new(:ok, :error) do
     def ok? = ok
@@ -33,14 +35,19 @@ class ManualAllocator
     target = round(amount)
     return failure('Enter an amount of zero or more.') if target.negative?
 
+    # User-then-bucket order matches the other services (linkers lock the
+    # transaction/bucket, never the user; fund_pending_for locks the user only),
+    # so this can't deadlock against them.
     @user.with_lock do
-      delta = target - @item.bucket_balance
-      if delta.positive?
-        return failure("That's more than your Free-to-Spend.") if delta > @user.free_to_spend
+      @item.with_lock do
+        delta = target - @item.bucket_balance
+        if delta.positive?
+          return failure("That's more than your Free-to-Spend.") if delta > @user.free_to_spend
 
-        add(delta)
-      elsif delta.negative?
-        remove(-delta)
+          add(delta)
+        elsif delta.negative?
+          remove(-delta)
+        end
       end
     end
 

--- a/app/views/expenses/_balance.html.erb
+++ b/app/views/expenses/_balance.html.erb
@@ -1,0 +1,33 @@
+<%# locals: (expense:) %>
+<%# Editable "Allocated" total, part of the main edit form so the drawer's
+    Update button saves it alongside the expense. ExpensesController#update reads
+    :allocated_amount and sets the bucket to it, moving the difference to/from
+    Free-to-Spend. Only meaningful once saved and a bank is linked. %>
+<% if expense.persisted? && Current.user.banks.exists? %>
+  <%
+    bucket = expense.bucket_balance
+    fts = Current.user.free_to_spend
+    percent = expense.amount.positive? ? [ (bucket / expense.amount * 100).to_i, 100 ].min : 0
+  %>
+
+  <fieldset class="fieldset">
+    <legend class="fieldset-legend justify-start">Allocated</legend>
+    <% if @allocation_error.present? %>
+      <p class="text-error text-xs mb-1"><%= @allocation_error %></p>
+    <% end %>
+    <label class="input w-full <%= 'input-error' if @allocation_error.present? %>">
+      <span class="text-base-content/50">$</span>
+      <%= number_field_tag :allocated_amount, number_with_precision(bucket, precision: 2),
+            step: 0.01, min: 0, inputmode: "decimal", class: "grow",
+            "aria-label": "Amount allocated" %>
+    </label>
+    <div class="flex items-center gap-2 mt-2">
+      <progress class="progress progress-primary h-1.5 flex-1" value="<%= percent %>" max="100"
+                aria-label="<%= expense.name %> funded <%= percent %>%"></progress>
+      <span class="text-xs text-base-content/60 tabular-nums shrink-0">
+        <%= number_to_currency(bucket) %> of <%= number_to_currency(expense.amount) %>
+      </span>
+    </div>
+    <p class="label"><%= number_to_currency(fts) %> left in Free-to-Spend</p>
+  </fieldset>
+<% end %>

--- a/app/views/expenses/_form.html.erb
+++ b/app/views/expenses/_form.html.erb
@@ -21,19 +21,25 @@
 
       <fieldset class="fieldset">
         <legend class="fieldset-legend justify-start gap-0">
-          Amount<span class="text-error tooltip tooltip-error tooltip-right cursor-pointer" data-tip="Required">•</span>
+          Amount needed<span class="text-error tooltip tooltip-error tooltip-right cursor-pointer" data-tip="Required">•</span>
         </legend>
         <div class="relative">
-          <%= f.number_field :amount,
-                value: expense.amount,
-                step: 0.01,
-                min: 0.01,
-                class: "input w-full #{expense.errors[:amount].any? ? 'input-error' : ''}" %>
+          <label class="input w-full <%= 'input-error' if expense.errors[:amount].any? %>">
+            <span class="text-base-content/50">$</span>
+            <%= f.number_field :amount,
+                  value: expense.amount,
+                  step: 0.01,
+                  min: 0.01,
+                  inputmode: "decimal",
+                  class: "grow" %>
+          </label>
           <% if expense.errors[:amount].any? %>
             <p class="absolute left-0 top-full text-error mt-2 text-xs"><%= expense.errors.full_messages_for(:amount).first %></p>
           <% end %>
         </div>
       </fieldset>
+
+      <%= render "expenses/balance", expense: expense %>
 
       <fieldset class="fieldset">
         <legend class="fieldset-legend justify-start gap-0">

--- a/app/views/goals/_balance.html.erb
+++ b/app/views/goals/_balance.html.erb
@@ -1,0 +1,33 @@
+<%# locals: (goal:) %>
+<%# Editable "Allocated" total, part of the main edit form so the drawer's
+    Update button saves it alongside the goal. GoalsController#update reads
+    :allocated_amount and sets the bucket to it, moving the difference to/from
+    Free-to-Spend. Only meaningful once saved and a bank is linked. %>
+<% if goal.persisted? && Current.user.banks.exists? %>
+  <%
+    bucket = goal.bucket_balance
+    fts = Current.user.free_to_spend
+    percent = goal.amount.positive? ? [ (bucket / goal.amount * 100).to_i, 100 ].min : 0
+  %>
+
+  <fieldset class="fieldset">
+    <legend class="fieldset-legend justify-start">Allocated</legend>
+    <% if @allocation_error.present? %>
+      <p class="text-error text-xs mb-1"><%= @allocation_error %></p>
+    <% end %>
+    <label class="input w-full <%= 'input-error' if @allocation_error.present? %>">
+      <span class="text-base-content/50">$</span>
+      <%= number_field_tag :allocated_amount, number_with_precision(bucket, precision: 2),
+            step: 0.01, min: 0, inputmode: "decimal", class: "grow",
+            "aria-label": "Amount allocated" %>
+    </label>
+    <div class="flex items-center gap-2 mt-2">
+      <progress class="progress progress-primary h-1.5 flex-1" value="<%= percent %>" max="100"
+                aria-label="<%= goal.name %> funded <%= percent %>%"></progress>
+      <span class="text-xs text-base-content/60 tabular-nums shrink-0">
+        <%= number_to_currency(bucket) %> of <%= number_to_currency(goal.amount) %>
+      </span>
+    </div>
+    <p class="label"><%= number_to_currency(fts) %> left in Free-to-Spend</p>
+  </fieldset>
+<% end %>

--- a/app/views/goals/_form.html.erb
+++ b/app/views/goals/_form.html.erb
@@ -21,19 +21,25 @@
 
       <fieldset class="fieldset">
         <legend class="fieldset-legend justify-start gap-0">
-          Amount<span class="text-error tooltip tooltip-error tooltip-right cursor-pointer" data-tip="Required">•</span>
+          Amount needed<span class="text-error tooltip tooltip-error tooltip-right cursor-pointer" data-tip="Required">•</span>
         </legend>
         <div class="relative">
-          <%= f.number_field :amount,
-                value: goal.amount,
-                step: 0.01,
-                min: 0.01,
-                class: "input w-full #{goal.errors[:amount].any? ? 'input-error' : ''}" %>
+          <label class="input w-full <%= 'input-error' if goal.errors[:amount].any? %>">
+            <span class="text-base-content/50">$</span>
+            <%= f.number_field :amount,
+                  value: goal.amount,
+                  step: 0.01,
+                  min: 0.01,
+                  inputmode: "decimal",
+                  class: "grow" %>
+          </label>
           <% if goal.errors[:amount].any? %>
             <p class="absolute left-0 top-full text-error mt-2 text-xs"><%= goal.errors.full_messages_for(:amount).first %></p>
           <% end %>
         </div>
       </fieldset>
+
+      <%= render "goals/balance", goal: goal %>
 
       <fieldset class="fieldset">
         <legend class="fieldset-legend justify-start gap-0">

--- a/app/views/transactions/_free_to_spend.html.erb
+++ b/app/views/transactions/_free_to_spend.html.erb
@@ -5,18 +5,8 @@
 <div id="free_to_spend" class="text-right">
   <% if Current.user.banks.exists? %>
     <%
-      available = Current.user.bank_accounts.sum(:available_balance)
-      expense_allocated = Current.user.expenses
-                                 .joins(:allocations)
-                                 .where.not(allocations: { funded_at: nil })
-                                 .where('allocations.amount > allocations.spent_amount')
-                                 .sum(Arel.sql('allocations.amount - allocations.spent_amount'))
-      goal_allocated = Current.user.goals
-                              .joins(:allocations)
-                              .where.not(allocations: { funded_at: nil })
-                              .where('allocations.amount > allocations.spent_amount')
-                              .sum(Arel.sql('allocations.amount - allocations.spent_amount'))
-      allocated = expense_allocated + goal_allocated
+      available = Current.user.available_balance
+      allocated = Current.user.allocated_in_buckets
       free = available - allocated
     %>
     <details class="group">

--- a/db/migrate/20260625000001_allow_manual_allocations.rb
+++ b/db/migrate/20260625000001_allow_manual_allocations.rb
@@ -1,0 +1,25 @@
+class AllowManualAllocations < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  # A manual allocation is an Allocation with no funding_event — the user put
+  # money into a bucket directly rather than a paycheck proposing it. Drop the
+  # NOT NULL so those rows can exist, and add partial unique indexes so a bucket
+  # can only have one manual row (the running net manual contribution). The
+  # existing [funding_event_id, expense_id]/[..goal_id] unique indexes only
+  # cover auto rows, which always carry a funding_event_id.
+  def change
+    change_column_null :allocations, :funding_event_id, true
+
+    add_index :allocations, :expense_id,
+              unique: true,
+              where: 'funding_event_id IS NULL AND expense_id IS NOT NULL',
+              name: 'index_allocations_on_manual_expense_id',
+              algorithm: :concurrently
+
+    add_index :allocations, :goal_id,
+              unique: true,
+              where: 'funding_event_id IS NULL AND goal_id IS NOT NULL',
+              name: 'index_allocations_on_manual_goal_id',
+              algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_22_053817) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_25_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -22,17 +22,19 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_22_053817) do
     t.datetime "created_at", null: false
     t.uuid "expense_id"
     t.datetime "funded_at"
-    t.uuid "funding_event_id", null: false
+    t.uuid "funding_event_id"
     t.uuid "goal_id"
     t.decimal "spent_amount", precision: 10, scale: 2, default: "0.0", null: false
     t.datetime "spent_at"
     t.uuid "spent_by_transaction_id"
     t.datetime "updated_at", null: false
     t.index ["expense_id"], name: "index_allocations_on_expense_id"
+    t.index ["expense_id"], name: "index_allocations_on_manual_expense_id", unique: true, where: "((funding_event_id IS NULL) AND (expense_id IS NOT NULL))"
     t.index ["funding_event_id", "expense_id"], name: "index_allocations_on_funding_event_id_and_expense_id", unique: true, where: "(expense_id IS NOT NULL)"
     t.index ["funding_event_id", "goal_id"], name: "index_allocations_on_funding_event_id_and_goal_id", unique: true, where: "(goal_id IS NOT NULL)"
     t.index ["funding_event_id"], name: "index_allocations_on_funding_event_id"
     t.index ["goal_id"], name: "index_allocations_on_goal_id"
+    t.index ["goal_id"], name: "index_allocations_on_manual_goal_id", unique: true, where: "((funding_event_id IS NULL) AND (goal_id IS NOT NULL))"
     t.index ["spent_by_transaction_id"], name: "index_allocations_on_spent_by_transaction_id"
     t.check_constraint "num_nonnulls(expense_id, goal_id) = 1", name: "allocations_exactly_one_allocatable"
   end

--- a/test/controllers/expenses_controller_test.rb
+++ b/test/controllers/expenses_controller_test.rb
@@ -184,14 +184,14 @@ class ExpensesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 5.00, expense.bucket_balance.to_f
   end
 
-  test 'update with an allocated amount over free-to-spend re-renders with an error' do
+  test 'update with an allocated amount over free-to-spend re-renders with an error and rolls back' do
     sign_in_as(@user)
     expense = expenses(:netflix)
 
     patch expense_url(expense),
           params: {
             expense: {
-              name: 'Netflix', amount: '22.99', cadence: 'monthly',
+              name: 'Renamed', amount: '22.99', cadence: 'monthly',
               due_on: '2026-02-14', funding_schedule_id: @schedule.id
             },
             allocated_amount: '999999'
@@ -200,7 +200,9 @@ class ExpensesControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :unprocessable_content
     assert_match(/Free-to-Spend/, response.body)
-    assert_equal 8.00, expense.reload.bucket_balance.to_f, 'bucket left untouched on error'
+    expense.reload
+    assert_equal 8.00, expense.bucket_balance.to_f, 'bucket left untouched on error'
+    assert_equal 'Netflix', expense.name, 'expense edit rolled back with the allocation'
   end
 
   test 'update without an allocated amount leaves the bucket untouched' do

--- a/test/controllers/expenses_controller_test.rb
+++ b/test/controllers/expenses_controller_test.rb
@@ -167,6 +167,58 @@ class ExpensesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 22.99, expense.amount.to_f
   end
 
+  test 'update applies the allocated amount alongside expense changes' do
+    sign_in_as(@user)
+    expense = expenses(:netflix) # starts with an $8.00 funded allocation
+
+    patch expense_url(expense), params: {
+      expense: {
+        name: 'Netflix Premium', amount: '22.99', cadence: 'monthly',
+        due_on: '2026-02-14', funding_schedule_id: @schedule.id
+      },
+      allocated_amount: '5.00'
+    }
+
+    assert_redirected_to expenses_path
+    assert_equal 'Netflix Premium', expense.reload.name
+    assert_equal 5.00, expense.bucket_balance.to_f
+  end
+
+  test 'update with an allocated amount over free-to-spend re-renders with an error' do
+    sign_in_as(@user)
+    expense = expenses(:netflix)
+
+    patch expense_url(expense),
+          params: {
+            expense: {
+              name: 'Netflix', amount: '22.99', cadence: 'monthly',
+              due_on: '2026-02-14', funding_schedule_id: @schedule.id
+            },
+            allocated_amount: '999999'
+          },
+          headers: { Accept: 'text/vnd.turbo-stream.html' }
+
+    assert_response :unprocessable_content
+    assert_match(/Free-to-Spend/, response.body)
+    assert_equal 8.00, expense.reload.bucket_balance.to_f, 'bucket left untouched on error'
+  end
+
+  test 'update without an allocated amount leaves the bucket untouched' do
+    sign_in_as(@user)
+    expense = expenses(:netflix)
+    ManualAllocator.set_balance(item: expense, amount: 12.00)
+
+    patch expense_url(expense), params: {
+      expense: {
+        name: 'Netflix', amount: '22.99', cadence: 'monthly',
+        due_on: '2026-02-14', funding_schedule_id: @schedule.id
+      }
+    }
+
+    assert_redirected_to expenses_path
+    assert_equal 12.00, expense.reload.bucket_balance.to_f
+  end
+
   test 'update with turbo_stream accept and invalid input returns html form' do
     sign_in_as(@user)
     expense = expenses(:netflix)

--- a/test/controllers/goals_controller_test.rb
+++ b/test/controllers/goals_controller_test.rb
@@ -190,19 +190,21 @@ class GoalsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 300.00, @goal.bucket_balance.to_f
   end
 
-  test 'update with an allocated amount over free-to-spend re-renders with an error' do
+  test 'update with an allocated amount over free-to-spend re-renders with an error and rolls back' do
     sign_in_as(@user)
 
     patch goal_url(@goal),
           params: {
-            goal: { name: 'Vacation', amount: '1200.00', cadence: 'yearly', due_on: '2026-12-01', funding_schedule_id: @schedule.id },
+            goal: { name: 'Renamed', amount: '1200.00', cadence: 'yearly', due_on: '2026-12-01', funding_schedule_id: @schedule.id },
             allocated_amount: '999999'
           },
           headers: { Accept: 'text/vnd.turbo-stream.html' }
 
     assert_response :unprocessable_content
     assert_match(/Free-to-Spend/, response.body)
-    assert_equal 0, @goal.reload.bucket_balance.to_f
+    @goal.reload
+    assert_equal 0, @goal.bucket_balance.to_f
+    assert_equal 'Vacation', @goal.name, 'goal edit rolled back with the allocation'
   end
 
   test 'update with turbo_stream accept and invalid input returns html form' do

--- a/test/controllers/goals_controller_test.rb
+++ b/test/controllers/goals_controller_test.rb
@@ -174,6 +174,37 @@ class GoalsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 2200.00, @goal.amount.to_f
   end
 
+  test 'update applies the allocated amount alongside goal changes' do
+    sign_in_as(@user)
+
+    patch goal_url(@goal), params: {
+      goal: {
+        name: 'Big vacation', amount: '2200.00', cadence: 'yearly',
+        due_on: '2026-12-01', funding_schedule_id: @schedule.id
+      },
+      allocated_amount: '300.00'
+    }
+
+    assert_redirected_to goals_path
+    assert_equal 'Big vacation', @goal.reload.name
+    assert_equal 300.00, @goal.bucket_balance.to_f
+  end
+
+  test 'update with an allocated amount over free-to-spend re-renders with an error' do
+    sign_in_as(@user)
+
+    patch goal_url(@goal),
+          params: {
+            goal: { name: 'Vacation', amount: '1200.00', cadence: 'yearly', due_on: '2026-12-01', funding_schedule_id: @schedule.id },
+            allocated_amount: '999999'
+          },
+          headers: { Accept: 'text/vnd.turbo-stream.html' }
+
+    assert_response :unprocessable_content
+    assert_match(/Free-to-Spend/, response.body)
+    assert_equal 0, @goal.reload.bucket_balance.to_f
+  end
+
   test 'update with turbo_stream accept and invalid input returns html form' do
     sign_in_as(@user)
 

--- a/test/models/allocation_test.rb
+++ b/test/models/allocation_test.rb
@@ -53,4 +53,26 @@ class AllocationTest < ActiveSupport::TestCase
     assert_not allocation.valid?
     assert_includes allocation.errors[:base], 'must belong to exactly one of an expense or a goal'
   end
+
+  test 'allows a manual allocation with no funding_event' do
+    allocation = Allocation.new(expense: @expense, amount: 25, funded_at: Time.current)
+
+    assert allocation.valid?
+  end
+
+  test 'enforces one manual allocation per expense' do
+    Allocation.create!(expense: @expense, amount: 10, funded_at: Time.current)
+    duplicate = Allocation.new(expense: @expense, amount: 5, funded_at: Time.current)
+
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:expense_id], 'has already been taken'
+  end
+
+  test 'manual scope returns allocations without a funding_event' do
+    manual = Allocation.create!(expense: @expense, amount: 10, funded_at: Time.current)
+    auto = Allocation.create!(funding_event: @event, expense: @expense, amount: 5)
+
+    assert_includes Allocation.manual, manual
+    assert_not_includes Allocation.manual, auto
+  end
 end

--- a/test/models/expense_test.rb
+++ b/test/models/expense_test.rb
@@ -143,4 +143,26 @@ class ExpenseTest < ActiveSupport::TestCase
       assert_equal 12.00, expense.per_paycheck_amount.to_f # 12 / 1
     end
   end
+
+  test 'per_paycheck_amount subtracts money already in the bucket' do
+    # 3 paychecks until due (Jan 15, 29, Feb 12). $9.99 target with $3 funded
+    # leaves $6.99 to move over 3 paychecks = $2.33.
+    travel_to Date.new(2026, 1, 5) do
+      expense = build(due_on: Date.new(2026, 2, 14), amount: 9.99)
+      expense.save!
+      Allocation.create!(funding_event: funding_events(:paycheck_first), expense: expense, amount: 3, funded_at: Time.current)
+
+      assert_in_delta 2.33, expense.per_paycheck_amount.to_f, 0.01
+    end
+  end
+
+  test 'per_paycheck_amount is zero once the bucket is fully funded' do
+    travel_to Date.new(2026, 1, 5) do
+      expense = build(due_on: Date.new(2026, 2, 14), amount: 9.99)
+      expense.save!
+      Allocation.create!(funding_event: funding_events(:paycheck_first), expense: expense, amount: 9.99, funded_at: Time.current)
+
+      assert_equal 0, expense.per_paycheck_amount.to_f
+    end
+  end
 end

--- a/test/models/goal_test.rb
+++ b/test/models/goal_test.rb
@@ -156,4 +156,26 @@ class GoalTest < ActiveSupport::TestCase
       assert_equal 12.00, goal.per_paycheck_amount.to_f # 12 / 1
     end
   end
+
+  test 'per_paycheck_amount subtracts money already in the bucket' do
+    # 3 paychecks until due (Jan 15, 29, Feb 12). $9.99 target with $3 funded
+    # leaves $6.99 to move over 3 paychecks = $2.33.
+    travel_to Date.new(2026, 1, 5) do
+      goal = build(cadence: 'monthly', due_on: Date.new(2026, 2, 14), amount: 9.99)
+      goal.save!
+      Allocation.create!(funding_event: funding_events(:paycheck_first), goal: goal, amount: 3, funded_at: Time.current)
+
+      assert_in_delta 2.33, goal.per_paycheck_amount.to_f, 0.01
+    end
+  end
+
+  test 'per_paycheck_amount is zero once the bucket is fully funded' do
+    travel_to Date.new(2026, 1, 5) do
+      goal = build(cadence: 'monthly', due_on: Date.new(2026, 2, 14), amount: 9.99)
+      goal.save!
+      Allocation.create!(funding_event: funding_events(:paycheck_first), goal: goal, amount: 9.99, funded_at: Time.current)
+
+      assert_equal 0, goal.per_paycheck_amount.to_f
+    end
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -149,4 +149,32 @@ class UserTest < ActiveSupport::TestCase
   ensure
     ENV['ALLOWED_EMAILS'] = original
   end
+
+  test 'free_to_spend is available balance minus funded unspent buckets' do
+    user = users(:johndoe)
+    user.expenses.destroy_all
+    user.funding_schedules.destroy_all
+    schedule = user.funding_schedules.create!(name: 'Paycheck', cadence: 'biweekly', start_date: Date.new(2026, 1, 1))
+    expense = user.expenses.create!(name: 'Rent', amount: 100, cadence: 'monthly', due_on: Date.new(2026, 2, 1), funding_schedule: schedule)
+    event = schedule.funding_events.create!(occurs_on: Date.new(2026, 1, 1))
+    Allocation.create!(funding_event: event, expense: expense, amount: 100, funded_at: Time.current)
+
+    # johndoe has $6,000 available across chase_checking + chase_savings.
+    assert_equal 6000, user.available_balance.to_f
+    assert_equal 100, user.allocated_in_buckets.to_f
+    assert_equal 5900, user.free_to_spend.to_f
+  end
+
+  test 'free_to_spend ignores pending (unfunded) allocations' do
+    user = users(:johndoe)
+    user.expenses.destroy_all
+    user.funding_schedules.destroy_all
+    schedule = user.funding_schedules.create!(name: 'Paycheck', cadence: 'biweekly', start_date: Date.new(2026, 1, 1))
+    expense = user.expenses.create!(name: 'Rent', amount: 100, cadence: 'monthly', due_on: Date.new(2026, 2, 1), funding_schedule: schedule)
+    event = schedule.funding_events.create!(occurs_on: Date.new(2026, 1, 1))
+    Allocation.create!(funding_event: event, expense: expense, amount: 100, funded_at: nil)
+
+    assert_equal 0, user.allocated_in_buckets.to_f
+    assert_equal 6000, user.free_to_spend.to_f
+  end
 end

--- a/test/services/manual_allocator_test.rb
+++ b/test/services/manual_allocator_test.rb
@@ -108,6 +108,21 @@ class ManualAllocatorTest < ActiveSupport::TestCase
     end
   end
 
+  test 'locks the bucket row to serialize with transaction linkers' do
+    # ExpenseLinker/GoalLinker write spent_amount under expense.with_lock; without
+    # taking the same lock here, remove could persist amount < spent_amount.
+    locked = false
+    @expense.define_singleton_method(:with_lock) do |&block|
+      locked = true
+      block.call
+    end
+
+    ManualAllocator.new(@expense).set_balance(50)
+
+    assert locked, 'set_balance must lock the bucket row'
+    assert_equal 50, @expense.bucket_balance.to_f
+  end
+
   test 'works for goals too' do
     goal = @user.goals.create!(name: 'New laptop', amount: 2000, cadence: 'yearly', due_on: Date.new(2026, 12, 1), funding_schedule: @schedule)
 

--- a/test/services/manual_allocator_test.rb
+++ b/test/services/manual_allocator_test.rb
@@ -1,0 +1,119 @@
+require 'test_helper'
+
+class ManualAllocatorTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:johndoe) # $6,000 available across chase_checking + chase_savings
+    @user.expenses.destroy_all
+    @user.goals.destroy_all
+    @user.funding_schedules.destroy_all
+
+    @schedule = @user.funding_schedules.create!(name: 'Paycheck', cadence: 'biweekly', start_date: Date.new(2026, 1, 1))
+    @expense  = @user.expenses.create!(name: 'Rent', amount: 1000, cadence: 'monthly', due_on: Date.new(2026, 2, 1), funding_schedule: @schedule)
+  end
+
+  test 'setting a balance from zero allocates and lowers free-to-spend' do
+    result = ManualAllocator.set_balance(item: @expense, amount: 250)
+
+    assert result.ok?
+    assert_equal 250, @expense.reload.bucket_balance.to_f
+    assert_equal 5750, @user.free_to_spend.to_f
+    assert @expense.allocations.manual.first.funded_at.present?
+  end
+
+  test 'raising the balance only moves the difference' do
+    ManualAllocator.set_balance(item: @expense, amount: 100)
+    ManualAllocator.set_balance(item: @expense, amount: 400)
+
+    assert_equal 1, @expense.allocations.manual.count
+    assert_equal 400, @expense.reload.bucket_balance.to_f
+    assert_equal 5600, @user.free_to_spend.to_f
+  end
+
+  test 'raising the balance beyond free-to-spend is rejected' do
+    result = ManualAllocator.set_balance(item: @expense, amount: 6000.01)
+
+    assert_not result.ok?
+    assert_match(/free-to-spend/i, result.error)
+    assert_equal 0, @expense.reload.bucket_balance.to_f
+  end
+
+  test 'a negative balance is rejected' do
+    result = ManualAllocator.set_balance(item: @expense, amount: -5)
+
+    assert_not result.ok?
+  end
+
+  test 'lowering the balance returns money to free-to-spend' do
+    ManualAllocator.set_balance(item: @expense, amount: 300)
+
+    ManualAllocator.set_balance(item: @expense, amount: 200)
+
+    assert_equal 200, @expense.reload.bucket_balance.to_f
+    assert_equal 5800, @user.free_to_spend.to_f
+  end
+
+  test 'setting the balance to zero clears the manual allocation' do
+    ManualAllocator.set_balance(item: @expense, amount: 300)
+
+    ManualAllocator.set_balance(item: @expense, amount: 0)
+
+    assert_equal 0, @expense.allocations.manual.count
+    assert_equal 0, @expense.reload.bucket_balance.to_f
+  end
+
+  test 'lowering the balance draws down auto-allocated paycheck money too' do
+    event = @schedule.funding_events.create!(occurs_on: Date.new(2026, 1, 1))
+    auto = Allocation.create!(funding_event: event, expense: @expense, amount: 50, funded_at: Time.current)
+    assert_equal 50, @expense.bucket_balance.to_f
+
+    ManualAllocator.set_balance(item: @expense, amount: 30)
+
+    assert_equal 30, @expense.reload.bucket_balance.to_f
+    assert_equal 30, auto.reload.amount.to_f, 'auto allocation reduced'
+  end
+
+  test 'lowering draws from the manual row before auto paycheck money' do
+    event = @schedule.funding_events.create!(occurs_on: Date.new(2026, 1, 1))
+    auto = Allocation.create!(funding_event: event, expense: @expense, amount: 50, funded_at: Time.current)
+    ManualAllocator.set_balance(item: @expense, amount: 90) # +40 manual on top of the $50 auto
+
+    ManualAllocator.set_balance(item: @expense, amount: 60) # remove $30
+
+    assert_equal 50, auto.reload.amount.to_f, 'auto untouched while manual covers it'
+    assert_equal 10, @expense.allocations.manual.first.amount.to_f
+    assert_equal 60, @expense.reload.bucket_balance.to_f
+  end
+
+  test 'lowering never drops an allocation below what a transaction already spent' do
+    ManualAllocator.set_balance(item: @expense, amount: 100)
+    manual = @expense.allocations.manual.first
+    txn = Transaction.create!(name: 'PARTIAL', amount: 40, bank_account: bank_accounts(:chase_checking))
+    manual.update!(spent_amount: 40, spent_at: Time.current, spent_by_transaction: txn)
+    assert_equal 60, @expense.bucket_balance.to_f # 100 - 40 spent
+
+    ManualAllocator.set_balance(item: @expense, amount: 0)
+
+    assert_equal 0, @expense.reload.bucket_balance.to_f
+    assert_equal 40, manual.reload.amount.to_f, 'floored at the spent amount, row kept'
+  end
+
+  test 'fully allocating by hand leaves the engine nothing to propose' do
+    soon = @user.expenses.create!(name: 'Trip', amount: 1000, cadence: 'monthly', due_on: Date.new(2026, 1, 29), funding_schedule: @schedule)
+    ManualAllocator.set_balance(item: soon, amount: 1000)
+
+    event = @schedule.funding_events.create!(occurs_on: Date.new(2026, 1, 1))
+
+    assert_no_difference -> { soon.allocations.where(funding_event: event).count } do
+      AllocationEngine.propose_for(event)
+    end
+  end
+
+  test 'works for goals too' do
+    goal = @user.goals.create!(name: 'New laptop', amount: 2000, cadence: 'yearly', due_on: Date.new(2026, 12, 1), funding_schedule: @schedule)
+
+    result = ManualAllocator.set_balance(item: goal, amount: 500)
+
+    assert result.ok?
+    assert_equal 500, goal.reload.bucket_balance.to_f
+  end
+end


### PR DESCRIPTION
## What

Adds a way to manually allocate money to an expense or goal bucket from the edit drawer, on top of the existing automatic paycheck funding.

In each expense/goal edit drawer there's now an **Allocated** field (shown when a bank is linked) alongside **Amount needed**. Type the total you want allocated and hit the drawer's existing **Update** button — it saves the record and the allocation together. Raising it pulls the difference from Free-to-Spend; lowering it returns the difference.

## How it works

A manual allocation is just an `Allocation` with no `funding_event` and `funded_at` set, so it flows through everything that already reads allocations:
- counts toward `bucket_balance` and Free-to-Spend,
- is eligible for transaction linking,
- and is subtracted by `AllocationEngine.compute_proposed_amount`, so a manual top-up automatically lowers what future paychecks propose (no double-funding).

**`ManualAllocator.set_balance(item:, amount:)`** sets the bucket to a typed total under a per-user lock (matching the engine/linkers):
- increases go onto a single manual row (one per bucket, enforced by validation + a partial unique index),
- decreases draw down funded money — the manual row first, then auto allocations newest-first — never below what a linked transaction already spent,
- raising beyond current Free-to-Spend is rejected.

## Notable changes

- Folded the allocation into `expenses#update` / `goals#update` (one Update button); an over-Free-to-Spend amount re-renders the drawer with an inline error and leaves the bucket untouched.
- `per_paycheck_amount` now divides the **remaining** need (target − bucket) by paychecks-until-due, so funding a bucket shrinks the displayed per-paycheck rate (a fully-funded bucket shows \$0).
- Extracted `User#free_to_spend` / `#available_balance` / `#allocated_in_buckets`, reused by the Free-to-Spend summary and the allocation cap.
- Amount fields now show a `$` prefix and use `inputmode="decimal"` for a mobile numeric keypad.

## Migration

`allocations.funding_event_id` made nullable + partial unique indexes (`WHERE funding_event_id IS NULL`) so each bucket has at most one manual row. Follows the repo's `strong_migrations` pattern (`disable_ddl_transaction!`, concurrent indexes).

## Behavior note

Because buckets fund *toward a target by the due date*, manually lowering an allocation can be topped back up by future paychecks (the engine sees more remaining). That's consistent with how scheduled funding already works; a "manual reduction sticks / suppresses auto-funding" mode would be a separate change.

## Testing

- New `ManualAllocator` service tests: set higher/lower, cap at Free-to-Spend, clear to \$0, draw down auto paycheck money, floor at spent, engine no-double-fund, goals.
- Controller tests for the merged update (allocation applied with edits, over-FTS error, blank leaves bucket alone) on both expenses and goals.
- Model tests for manual `Allocation` validity/uniqueness, `User#free_to_spend`, and `per_paycheck_amount` reflecting the bucket.
- Full suite: **482 runs, 0 failures**. Rubocop + Brakeman clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)