### PR TITLE
Show bucket balance in picker; fix drawer scroll on mobile

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -187,6 +187,17 @@ input[type="date"]::-webkit-datetime-edit-year-field {
   touch-action: pan-y;
 }
 
+/* The drawer panel's turbo-frame must fill the panel and act as a flex
+   column so that h-full on its children resolves to the panel height.
+   Styled here rather than on the element so turbo_stream replacements
+   (which re-render the frame tag without inline classes) don't lose it. */
+turbo-frame#drawer_content {
+  flex: 1 1 0%;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
 /* #region Swipe navigation */
 .slide-in-left {
   animation: slideInLeft 0.2s ease-out forwards;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -80,7 +80,7 @@
     <div data-drawer-target="panel"
          class="fixed inset-y-0 right-0 z-50 w-full max-w-md bg-base-100 dark:bg-base-300 shadow-2xl transform translate-x-full transition-transform duration-300 flex flex-col">
       <% unless content_for?(:drawer_frame_provided) %>
-        <%= turbo_frame_tag "drawer_content" %>
+        <%= turbo_frame_tag "drawer_content", class: "flex-1 min-h-0 flex flex-col" %>
       <% end %>
     </div>
   </body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -80,7 +80,7 @@
     <div data-drawer-target="panel"
          class="fixed inset-y-0 right-0 z-50 w-full max-w-md bg-base-100 dark:bg-base-300 shadow-2xl transform translate-x-full transition-transform duration-300 flex flex-col">
       <% unless content_for?(:drawer_frame_provided) %>
-        <%= turbo_frame_tag "drawer_content", class: "flex-1 min-h-0 flex flex-col" %>
+        <%= turbo_frame_tag "drawer_content" %>
       <% end %>
     </div>
   </body>

--- a/app/views/transactions/_transaction_detail.html.erb
+++ b/app/views/transactions/_transaction_detail.html.erb
@@ -164,6 +164,8 @@
       <% else %>
         <% user_expenses = Current.user.expenses.order(:name).to_a %>
         <% user_goals = Current.user.goals.order(:name).to_a %>
+        <% expense_balances = Allocation.where(expense: user_expenses).where.not(funded_at: nil).where('amount > spent_amount').group(:expense_id).sum('amount - spent_amount') %>
+        <% goal_balances = Allocation.where(goal: user_goals).where.not(funded_at: nil).where('amount > spent_amount').group(:goal_id).sum('amount - spent_amount') %>
         <div class="flex items-center justify-between gap-3">
           <span class="text-sm text-base-content/50">Bucket</span>
           <button data-action="toggle#toggle" class="btn btn-ghost btn-sm text-primary">
@@ -202,7 +204,7 @@
                           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7" />
                         </svg>
                         <span class="truncate"><%= expense.name %></span>
-                        <span class="text-xs text-base-content/50 shrink-0 ml-auto"><%= number_to_currency(expense.amount) %></span>
+                        <span class="text-xs text-base-content/50 shrink-0 ml-auto"><%= number_to_currency(expense_balances[expense.id] || 0) %></span>
                       </button>
                     </li>
                   <% end %>
@@ -219,7 +221,7 @@
                           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7" />
                         </svg>
                         <span class="truncate"><%= goal.name %></span>
-                        <span class="text-xs text-base-content/50 shrink-0 ml-auto"><%= number_to_currency(goal.amount) %></span>
+                        <span class="text-xs text-base-content/50 shrink-0 ml-auto"><%= number_to_currency(goal_balances[goal.id] || 0) %></span>
                       </button>
                     </li>
                   <% end %>

--- a/app/views/transactions/_transaction_detail.html.erb
+++ b/app/views/transactions/_transaction_detail.html.erb
@@ -164,8 +164,8 @@
       <% else %>
         <% user_expenses = Current.user.expenses.order(:name).to_a %>
         <% user_goals = Current.user.goals.order(:name).to_a %>
-        <% expense_balances = Allocation.where(expense: user_expenses).where.not(funded_at: nil).where('amount > spent_amount').group(:expense_id).sum(Arel.sql('amount - spent_amount')) %>
-        <% goal_balances = Allocation.where(goal: user_goals).where.not(funded_at: nil).where('amount > spent_amount').group(:goal_id).sum(Arel.sql('amount - spent_amount')) %>
+        <% expense_balances = user_expenses.any? ? Allocation.where(expense: user_expenses).where.not(funded_at: nil).where('amount > spent_amount').group(:expense_id).sum(Arel.sql('amount - spent_amount')) : {} %>
+        <% goal_balances = user_goals.any? ? Allocation.where(goal: user_goals).where.not(funded_at: nil).where('amount > spent_amount').group(:goal_id).sum(Arel.sql('amount - spent_amount')) : {} %>
         <div class="flex items-center justify-between gap-3">
           <span class="text-sm text-base-content/50">Bucket</span>
           <button data-action="toggle#toggle" class="btn btn-ghost btn-sm text-primary">

--- a/app/views/transactions/_transaction_detail.html.erb
+++ b/app/views/transactions/_transaction_detail.html.erb
@@ -164,8 +164,8 @@
       <% else %>
         <% user_expenses = Current.user.expenses.order(:name).to_a %>
         <% user_goals = Current.user.goals.order(:name).to_a %>
-        <% expense_balances = Allocation.where(expense: user_expenses).where.not(funded_at: nil).where('amount > spent_amount').group(:expense_id).sum('amount - spent_amount') %>
-        <% goal_balances = Allocation.where(goal: user_goals).where.not(funded_at: nil).where('amount > spent_amount').group(:goal_id).sum('amount - spent_amount') %>
+        <% expense_balances = Allocation.where(expense: user_expenses).where.not(funded_at: nil).where('amount > spent_amount').group(:expense_id).sum(Arel.sql('amount - spent_amount')) %>
+        <% goal_balances = Allocation.where(goal: user_goals).where.not(funded_at: nil).where('amount > spent_amount').group(:goal_id).sum(Arel.sql('amount - spent_amount')) %>
         <div class="flex items-center justify-between gap-3">
           <span class="text-sm text-base-content/50">Bucket</span>
           <button data-action="toggle#toggle" class="btn btn-ghost btn-sm text-primary">


### PR DESCRIPTION
## Summary

- **Transaction picker**: in the expense/goal assignment picker, each row now shows the bucket's current funded balance (e.g. `$42.00`) instead of the target amount, so users can see how much is already saved when deciding where to assign a transaction. Balances are precomputed in two grouped SQL queries to avoid N+1.
- **Drawer scroll on mobile**: the `turbo-frame` in the drawer panel was missing `flex-1`, so its height matched its content rather than the full panel height. `h-full` on the inner form div resolved to content height, making `overflow-y-auto` a no-op. Added `flex-1 min-h-0 flex flex-col` to the frame so it fills the panel. Fixes scroll on the expense and goal edit forms on mobile.

## Test plan

- [ ] Open a transaction and tap Assign — verify the picker shows each expense/goal's current bucket balance, not the target amount
- [ ] Open expense edit from the expenses list on a mobile viewport — verify the form scrolls when content overflows
- [ ] Same for goal edit form
- [ ] Verify the transaction detail drawer still scrolls correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)